### PR TITLE
Add objectives CLI command for generating growth objectives

### DIFF
--- a/src/skene_growth/objectives/__init__.py
+++ b/src/skene_growth/objectives/__init__.py
@@ -1,0 +1,9 @@
+"""
+Growth objectives generation module.
+
+Generates prioritized growth objectives based on manifest and template data.
+"""
+
+from skene_growth.objectives.generator import generate_objectives, write_objectives_output
+
+__all__ = ["generate_objectives", "write_objectives_output"]

--- a/src/skene_growth/objectives/generator.py
+++ b/src/skene_growth/objectives/generator.py
@@ -1,0 +1,218 @@
+"""
+LLM-driven growth objectives generation.
+
+Generates 3 prioritized growth objectives based on manifest and template data.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from skene_growth.llm.base import LLMClient
+
+
+def _build_prompt(
+    manifest_data: dict[str, Any],
+    template_data: dict[str, Any],
+    quarter: str | None = None,
+    guidance: str | None = None,
+) -> str:
+    """Build a prompt for generating growth objectives."""
+    manifest_json = json.dumps(manifest_data, indent=2, default=str)
+    template_json = json.dumps(template_data, indent=2, default=str)
+
+    quarter_context = f"for {quarter}" if quarter else "for the current period"
+    
+    guidance_section = ""
+    if guidance:
+        guidance_section = f"""
+
+## User Guidance:
+{guidance}
+
+**IMPORTANT:** Please prioritize objectives that align with the user's guidance above. The user's guidance should strongly influence which lifecycle stages and metrics you select.
+"""
+
+    return f"""You are a Product-Led Growth (PLG) strategist. Your task is to analyze the project manifest and growth template to identify the 3 most impactful growth objectives {quarter_context}.
+
+## Project Manifest (Current State):
+{manifest_json}
+
+## Growth Template (Available Lifecycles & Metrics):
+{template_json}{guidance_section}
+
+## Your Task:
+
+Based on the manifest data (tech stack, growth hubs, GTM gaps) and the available lifecycle metrics from the template, select exactly 3 growth objectives that would have the highest impact.
+
+For each objective:
+1. Choose a lifecycle stage from the template (e.g., ACQUISITION, ACTIVATION, RETENTION, etc.)
+2. Select the most relevant metric from that lifecycle's metrics array
+3. Set a specific, achievable target based on the healthyBenchmark
+4. Define a tolerance range (typically +/- 5-20% depending on the metric)
+
+Prioritize objectives that:
+- Address gaps identified in the manifest's gtm_gaps
+- Align with the project's current growth hubs
+- Are measurable and actionable
+- Cover different lifecycle stages for balanced growth
+
+Return your response as a JSON array with exactly 3 objects:
+```json
+[
+  {{
+    "lifecycle": "LIFECYCLE_NAME",
+    "metric": "Metric Name",
+    "target": "Specific target value",
+    "tolerance": "Tolerance range description"
+  }},
+  ...
+]
+```
+
+Return ONLY the JSON array, no other text or markdown code blocks.
+"""
+
+
+def _parse_json_response(response: str) -> list[dict[str, Any]]:
+    """Parse JSON array from LLM response."""
+    response = response.strip()
+
+    # Try direct JSON parse first
+    try:
+        parsed = json.loads(response)
+        if isinstance(parsed, list):
+            return parsed
+    except json.JSONDecodeError:
+        pass
+
+    # Try extracting from markdown code fence
+    json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", response, re.DOTALL)
+    if json_match:
+        try:
+            parsed = json.loads(json_match.group(1).strip())
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+    # Try finding JSON array in text
+    arr_match = re.search(r"(\[.*\])", response, re.DOTALL)
+    if arr_match:
+        try:
+            parsed = json.loads(arr_match.group(1).strip())
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+    raise ValueError("Could not parse LLM response as JSON array.")
+
+
+def _validate_objectives(objectives: list[dict[str, Any]]) -> None:
+    """Validate that objectives have required fields."""
+    if len(objectives) != 3:
+        logger.warning(f"Expected 3 objectives, got {len(objectives)}")
+
+    required_fields = ["lifecycle", "metric", "target", "tolerance"]
+    for i, obj in enumerate(objectives):
+        missing = [field for field in required_fields if field not in obj]
+        if missing:
+            raise ValueError(f"Objective {i + 1} missing required fields: {missing}")
+
+
+def _format_markdown(
+    objectives: list[dict[str, Any]],
+    quarter: str | None = None,
+) -> str:
+    """Format objectives as markdown."""
+    title = f"# Growth Objectives {quarter}" if quarter else "# Growth Objectives"
+    generated_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    lines = [
+        title,
+        "",
+        f"*Generated on {generated_date}*",
+        "",
+    ]
+
+    for obj in objectives:
+        lifecycle = obj.get("lifecycle", "Unknown")
+        metric = obj.get("metric", "Unknown")
+        target = obj.get("target", "TBD")
+        tolerance = obj.get("tolerance", "TBD")
+
+        lines.extend([
+            f"## {lifecycle}",
+            f"- **Metric:** {metric}",
+            f"- **Target:** {target}",
+            f"- **Tolerance:** {tolerance}",
+            "",
+        ])
+
+    lines.append("---")
+    lines.append("*Growth objectives generated by skene-growth.*")
+
+    return "\n".join(lines)
+
+
+async def generate_objectives(
+    llm: LLMClient,
+    manifest_data: dict[str, Any],
+    template_data: dict[str, Any],
+    quarter: str | None = None,
+    guidance: str | None = None,
+) -> str:
+    """
+    Generate growth objectives markdown from manifest and template data.
+
+    Args:
+        llm: LLM client for generation
+        manifest_data: Project manifest data (from growth-manifest.json)
+        template_data: Growth template data (from growth-template.json)
+        quarter: Optional quarter label (e.g., "Q1", "Q2 2024")
+        guidance: Optional guidance text to influence objective selection
+
+    Returns:
+        Formatted markdown string with 3 growth objectives
+    """
+    prompt = _build_prompt(manifest_data, template_data, quarter, guidance)
+
+    logger.info(f"Generating growth objectives{' for ' + quarter if quarter else ''}...")
+    response = await llm.generate_content(prompt)
+
+    objectives = _parse_json_response(response)
+    _validate_objectives(objectives)
+
+    markdown = _format_markdown(objectives, quarter)
+
+    logger.success(f"Generated {len(objectives)} growth objectives")
+    return markdown
+
+
+def write_objectives_output(
+    markdown_content: str,
+    output_path: Path | str,
+) -> Path:
+    """
+    Write objectives markdown to file.
+
+    Args:
+        markdown_content: Formatted markdown content
+        output_path: Path to write the file
+
+    Returns:
+        Path to the written file
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown_content)
+
+    logger.info(f"Wrote growth objectives to {output_path}")
+    return output_path

--- a/tests/test_objectives/__init__.py
+++ b/tests/test_objectives/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for objectives module."""

--- a/tests/test_objectives/test_generator.py
+++ b/tests/test_objectives/test_generator.py
@@ -1,0 +1,369 @@
+"""Tests for objectives generator module."""
+
+import json
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from skene_growth.llm.base import LLMClient
+from skene_growth.objectives.generator import (
+    _format_markdown,
+    _parse_json_response,
+    _validate_objectives,
+    generate_objectives,
+    write_objectives_output,
+)
+
+
+class FakeLLM(LLMClient):
+    """Fake LLM client for testing."""
+
+    def __init__(self, response: str):
+        self.response = response
+        self.last_prompt: str | None = None
+
+    async def generate_content(self, prompt: str) -> str:
+        self.last_prompt = prompt
+        return self.response
+
+    async def generate_content_stream(self, prompt: str):
+        self.last_prompt = prompt
+        yield self.response
+
+    def get_model_name(self) -> str:
+        return "fake-model"
+
+    def get_provider_name(self) -> str:
+        return "fake-provider"
+
+
+def _build_sample_objectives() -> list[dict]:
+    """Build sample objectives for testing."""
+    return [
+        {
+            "lifecycle": "ACQUISITION",
+            "metric": "Website Conversion Rate",
+            "target": "> 2.5%",
+            "tolerance": "+/- 0.5% (2.0-3.0%)",
+        },
+        {
+            "lifecycle": "ACTIVATION",
+            "metric": "Time to Value",
+            "target": "< 10 minutes",
+            "tolerance": "+/- 20% (8-12 minutes)",
+        },
+        {
+            "lifecycle": "RETENTION",
+            "metric": "30-Day Retention",
+            "target": "> 25%",
+            "tolerance": "+/- 3% (22-28%)",
+        },
+    ]
+
+
+def _build_sample_manifest() -> dict:
+    """Build sample manifest for testing."""
+    return {
+        "version": "1.0",
+        "project_name": "Test Project",
+        "tech_stack": {
+            "language": "TypeScript",
+            "framework": "Next.js",
+        },
+        "growth_hubs": [
+            {"name": "User Auth", "description": "Authentication features"},
+        ],
+        "gtm_gaps": [
+            {"name": "Referral System", "description": "Missing referrals", "priority": "high"},
+        ],
+    }
+
+
+def _build_sample_template() -> dict:
+    """Build sample template for testing."""
+    return {
+        "title": "Test PLG Template",
+        "lifecycles": [
+            {
+                "name": "ACQUISITION",
+                "metrics": [
+                    {"name": "Conversion Rate", "howToMeasure": "% visitors who sign up", "healthyBenchmark": "> 2.5%"},
+                ],
+            },
+            {
+                "name": "ACTIVATION",
+                "metrics": [
+                    {"name": "Time to Value", "howToMeasure": "Time to first action", "healthyBenchmark": "< 10 min"},
+                ],
+            },
+        ],
+    }
+
+
+class TestParseJsonResponse:
+    """Tests for _parse_json_response function."""
+
+    def test_parse_raw_json_array(self):
+        """Test parsing raw JSON array."""
+        objectives = _build_sample_objectives()
+        response = json.dumps(objectives)
+
+        result = _parse_json_response(response)
+
+        assert len(result) == 3
+        assert result[0]["lifecycle"] == "ACQUISITION"
+
+    def test_parse_json_from_codefence(self):
+        """Test parsing JSON from markdown code fence."""
+        objectives = _build_sample_objectives()
+        response = f"```json\n{json.dumps(objectives, indent=2)}\n```"
+
+        result = _parse_json_response(response)
+
+        assert len(result) == 3
+        assert result[1]["lifecycle"] == "ACTIVATION"
+
+    def test_parse_json_from_codefence_no_language(self):
+        """Test parsing JSON from code fence without language tag."""
+        objectives = _build_sample_objectives()
+        response = f"```\n{json.dumps(objectives)}\n```"
+
+        result = _parse_json_response(response)
+
+        assert len(result) == 3
+
+    def test_parse_json_embedded_in_text(self):
+        """Test parsing JSON array embedded in text."""
+        objectives = _build_sample_objectives()
+        response = f"Here are the objectives:\n{json.dumps(objectives)}\nThese are good."
+
+        result = _parse_json_response(response)
+
+        assert len(result) == 3
+
+    def test_parse_invalid_json_raises_error(self):
+        """Test that invalid JSON raises ValueError."""
+        with pytest.raises(ValueError, match="Could not parse"):
+            _parse_json_response("This is not JSON at all")
+
+
+class TestValidateObjectives:
+    """Tests for _validate_objectives function."""
+
+    def test_validate_valid_objectives(self):
+        """Test validation passes for valid objectives."""
+        objectives = _build_sample_objectives()
+        # Should not raise
+        _validate_objectives(objectives)
+
+    def test_validate_missing_field_raises_error(self):
+        """Test validation fails when required field is missing."""
+        objectives = [
+            {"lifecycle": "ACQUISITION", "metric": "Rate"},  # missing target and tolerance
+        ]
+
+        with pytest.raises(ValueError, match="missing required fields"):
+            _validate_objectives(objectives)
+
+    def test_validate_does_not_raise_on_wrong_count(self):
+        """Test validation does not raise error when not exactly 3 objectives (just warns)."""
+        objectives = _build_sample_objectives()[:2]  # Only 2
+
+        # Should not raise - just logs a warning
+        _validate_objectives(objectives)
+
+
+class TestFormatMarkdown:
+    """Tests for _format_markdown function."""
+
+    def test_format_markdown_basic(self):
+        """Test basic markdown formatting."""
+        objectives = _build_sample_objectives()
+
+        result = _format_markdown(objectives)
+
+        assert "# Growth Objectives" in result
+        assert "## ACQUISITION" in result
+        assert "## ACTIVATION" in result
+        assert "## RETENTION" in result
+        assert "**Metric:** Website Conversion Rate" in result
+        assert "**Target:** > 2.5%" in result
+        assert "**Tolerance:** +/- 0.5% (2.0-3.0%)" in result
+
+    def test_format_markdown_with_quarter(self):
+        """Test markdown formatting with quarter label."""
+        objectives = _build_sample_objectives()
+
+        result = _format_markdown(objectives, quarter="Q1 2024")
+
+        assert "# Growth Objectives Q1 2024" in result
+
+    def test_format_markdown_includes_generated_date(self):
+        """Test that markdown includes generated date."""
+        objectives = _build_sample_objectives()
+
+        result = _format_markdown(objectives)
+
+        assert "*Generated on" in result
+
+    def test_format_markdown_date_is_system_date(self):
+        """Test that the generated date is the actual system date."""
+        objectives = _build_sample_objectives()
+        expected_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        result = _format_markdown(objectives)
+
+        assert f"*Generated on {expected_date}*" in result
+
+    def test_format_markdown_date_uses_frozen_time(self):
+        """Test that date comes from system, not LLM."""
+        objectives = _build_sample_objectives()
+
+        # Mock datetime to verify it's using system time
+        with patch("skene_growth.objectives.generator.datetime") as mock_datetime:
+            mock_datetime.now.return_value.strftime.return_value = "2099-12-31 23:59:59"
+            result = _format_markdown(objectives)
+
+        assert "*Generated on 2099-12-31 23:59:59*" in result
+        mock_datetime.now.assert_called_once()
+
+    def test_format_markdown_includes_footer(self):
+        """Test that markdown includes footer."""
+        objectives = _build_sample_objectives()
+
+        result = _format_markdown(objectives)
+
+        assert "Growth objectives generated by skene-growth" in result
+
+
+class TestGenerateObjectives:
+    """Tests for generate_objectives async function."""
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_success(self):
+        """Test successful objectives generation."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+
+        result = await generate_objectives(llm, manifest, template)
+
+        assert "# Growth Objectives" in result
+        assert "## ACQUISITION" in result
+        assert "**Metric:** Website Conversion Rate" in result
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_with_quarter(self):
+        """Test objectives generation with quarter label."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+
+        result = await generate_objectives(llm, manifest, template, quarter="Q2")
+
+        assert "# Growth Objectives Q2" in result
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_prompt_includes_manifest(self):
+        """Test that prompt includes manifest data."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+
+        await generate_objectives(llm, manifest, template)
+
+        assert llm.last_prompt is not None
+        assert "Test Project" in llm.last_prompt
+        assert "gtm_gaps" in llm.last_prompt or "Referral System" in llm.last_prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_prompt_includes_template(self):
+        """Test that prompt includes template data."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+
+        await generate_objectives(llm, manifest, template)
+
+        assert llm.last_prompt is not None
+        assert "ACQUISITION" in llm.last_prompt
+        assert "lifecycles" in llm.last_prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_with_guidance(self):
+        """Test objectives generation with guidance text."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+
+        result = await generate_objectives(llm, manifest, template, guidance="Focus on onboarding")
+
+        assert "# Growth Objectives" in result
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_prompt_includes_guidance(self):
+        """Test that prompt includes guidance when provided."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+        guidance = "I want all objectives to focus on onboarding"
+
+        await generate_objectives(llm, manifest, template, guidance=guidance)
+
+        assert llm.last_prompt is not None
+        assert "User Guidance" in llm.last_prompt
+        assert guidance in llm.last_prompt
+        assert "onboarding" in llm.last_prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_generate_objectives_prompt_without_guidance(self):
+        """Test that prompt doesn't include guidance section when not provided."""
+        objectives = _build_sample_objectives()
+        llm = FakeLLM(json.dumps(objectives))
+        manifest = _build_sample_manifest()
+        template = _build_sample_template()
+
+        await generate_objectives(llm, manifest, template)
+
+        assert llm.last_prompt is not None
+        assert "User Guidance" not in llm.last_prompt
+
+
+class TestWriteObjectivesOutput:
+    """Tests for write_objectives_output function."""
+
+    def test_write_objectives_output(self, tmp_path):
+        """Test writing objectives markdown to file."""
+        markdown_content = "# Growth Objectives\n\n## Test\n- **Metric:** Test"
+        output_path = tmp_path / "growth-objectives.md"
+
+        result = write_objectives_output(markdown_content, output_path)
+
+        assert result.exists()
+        assert result.read_text() == markdown_content
+
+    def test_write_objectives_output_creates_parent_dirs(self, tmp_path):
+        """Test that parent directories are created if they don't exist."""
+        markdown_content = "# Test"
+        output_path = tmp_path / "nested" / "dir" / "objectives.md"
+
+        result = write_objectives_output(markdown_content, output_path)
+
+        assert result.exists()
+        assert result.read_text() == markdown_content
+
+    def test_write_objectives_output_returns_path(self, tmp_path):
+        """Test that function returns the output path."""
+        markdown_content = "# Test"
+        output_path = tmp_path / "objectives.md"
+
+        result = write_objectives_output(markdown_content, output_path)
+
+        assert result == output_path


### PR DESCRIPTION
## Summary

This PR adds a new `objectives` CLI command that generates 3 prioritized growth objectives based on the project's growth manifest and template data.

## Changes

### New Features
- **New CLI command**: `skene-growth objectives` - Generates 3 prioritized growth objectives using LLM analysis
- **Guidance parameter**: `--guidance` flag allows users to influence objective selection (e.g., focus on onboarding, prioritize retention)
- **Quarter support**: `--quarter` parameter for labeling objectives with specific time periods
- **Auto-detection**: Automatically detects `growth-manifest.json` and `growth-template.json` files

### Implementation Details
- **New module**: `src/skene_growth/objectives/generator.py` - Core logic for generating objectives
  - LLM-driven analysis of manifest and template data
  - Validates objectives structure (lifecycle, metric, target, tolerance)
  - Formats output as markdown with timestamps
- **CLI integration**: Added `objectives` command to `main.py` with full parameter support
- **Comprehensive testing**: Added 24 test cases covering various scenarios

### Output Format
Generated markdown includes:
- Lifecycle stage (e.g., ACQUISITION, ACTIVATION, RETENTION)
- Metric name
- Target value
- Tolerance range
- Generation timestamp

## Files Changed
- `src/skene_growth/cli/main.py` (+261 lines) - New objectives command
- `src/skene_growth/objectives/__init__.py` (+9 lines) - Module initialization
- `src/skene_growth/objectives/generator.py` (+218 lines) - Core generator logic
- `tests/test_objectives/test_generator.py` (+369 lines) - Comprehensive test suite

## Testing
- 24 test cases covering:
  - Prompt building with/without guidance
  - JSON parsing from various LLM response formats
  - Objective validation
  - Markdown formatting
  - Error handling

## Usage Example
```bash
# Generate objectives with auto-detection
uvx skene-growth objectives

# With guidance
uvx skene-growth objectives --guidance "Focus on onboarding improvements"

# With quarter label
uvx skene-growth objectives --quarter "Q1 2024"
```