### PR TITLE
Add Codex provider with local ChatGPT auth

### DIFF
--- a/src/skene/cli/app.py
+++ b/src/skene/cli/app.py
@@ -64,6 +64,7 @@ _LOCAL_NO_KEY_PROVIDERS = (
     "ollama",
     *_OPENAI_COMPAT_PROVIDERS,
 )
+_EMBEDDED_AUTH_PROVIDERS = ("codex",)
 
 # Default upstream ingest URL when --local is used without --ingest-url
 DEFAULT_LOCAL_INGEST_BASE = "https://www.skene.ai"
@@ -72,6 +73,16 @@ DEFAULT_LOCAL_INGEST_BASE = "https://www.skene.ai"
 def is_local_provider(provider: str) -> bool:
     """Return True for providers that can run without a real API key."""
     return provider.lower() in _LOCAL_NO_KEY_PROVIDERS
+
+
+def uses_embedded_auth(provider: str) -> bool:
+    """Return True for providers that own authentication outside skene config."""
+    return provider.lower() in _EMBEDDED_AUTH_PROVIDERS
+
+
+def allows_missing_api_key(provider: str) -> bool:
+    """Return True for providers that do not require a stored API key."""
+    return is_local_provider(provider) or uses_embedded_auth(provider)
 
 
 def requires_base_url(provider: str) -> bool:
@@ -137,6 +148,7 @@ class ResolvedConfig:
     base_url: str | None
     debug: bool
     is_local: bool
+    allows_missing_api_key: bool
     config: Config  # raw config for command-specific fields
 
 
@@ -166,6 +178,7 @@ def resolve_cli_config(
     resolved_model = model or config.get("model") or default_model_for_provider(resolved_provider)
     resolved_api_key = api_key or config.api_key
     is_local = is_local_provider(resolved_provider)
+    allows_missing = allows_missing_api_key(resolved_provider)
 
     if requires_base_url(resolved_provider) and not resolved_base_url:
         error(f"The '{resolved_provider}' provider requires --base-url to be set.")
@@ -178,6 +191,7 @@ def resolve_cli_config(
         base_url=resolved_base_url,
         debug=resolved_debug,
         is_local=is_local,
+        allows_missing_api_key=allows_missing,
         config=config,
     )
 

--- a/src/skene/cli/commands/analyze.py
+++ b/src/skene/cli/commands/analyze.py
@@ -45,7 +45,7 @@ def analyze(
         None,
         "--provider",
         "-p",
-        help="LLM provider to use (openai, gemini, anthropic/claude, lmstudio, ollama, generic, skene)",
+        help="LLM provider to use (codex, openai, gemini, anthropic/claude, lmstudio, ollama, generic, skene)",
     ),
     model: str | None = typer.Option(
         None,
@@ -159,7 +159,7 @@ def analyze(
         resolved_output = Path(rc.config.output_dir) / "growth-manifest.json"
 
     # If no API key and not using local provider, show sample report or require key
-    if not rc.api_key and not rc.is_local:
+    if not rc.api_key and not rc.allows_missing_api_key:
         if features:
             warning(
                 "No API key provided. Feature analysis requires an LLM.\n"
@@ -176,6 +176,8 @@ def analyze(
     resolved_api_key = rc.api_key
     if not resolved_api_key and rc.is_local:
         resolved_api_key = rc.provider  # Dummy key for local server
+    elif not resolved_api_key and rc.allows_missing_api_key:
+        resolved_api_key = ""
 
     # If features only, use features mode
     mode_str = "docs" if product_docs else ("features" if features else "growth")

--- a/src/skene/cli/commands/build.py
+++ b/src/skene/cli/commands/build.py
@@ -44,7 +44,7 @@ def build(
         None,
         "--provider",
         "-p",
-        help="LLM provider: openai, gemini, anthropic, ollama, generic, skene (uses config if not provided)",
+        help="LLM provider: codex, openai, gemini, anthropic, ollama, generic, skene (uses config if not provided)",
     ),
     model: str | None = typer.Option(
         None,
@@ -160,7 +160,7 @@ async def _build_async(
 ):
     """Async implementation of build command."""
     # Validate LLM configuration
-    if not rc.api_key or not rc.provider:
+    if not rc.provider or (not rc.api_key and not rc.allows_missing_api_key):
         error(
             "LLM configuration required.\n\n"
             "Please set api_key and provider in one of:\n"
@@ -170,7 +170,7 @@ async def _build_async(
             "  4. Environment: SKENE_API_KEY\n\n"
             "Example config:\n"
             '  api_key = "your-api-key"\n'
-            '  provider = "gemini"  # or anthropic, openai, ollama, generic, skene\n'
+            '  provider = "gemini"  # or codex, anthropic, openai, ollama, generic, skene\n'
         )
         raise typer.Exit(1)
 
@@ -227,7 +227,7 @@ async def _build_async(
 
         llm = create_llm_client(
             rc.provider,
-            SecretStr(rc.api_key),
+            SecretStr(rc.api_key or ""),
             rc.model,
             base_url=rc.base_url,
             debug=rc.debug,

--- a/src/skene/cli/commands/plan.py
+++ b/src/skene/cli/commands/plan.py
@@ -47,7 +47,7 @@ def plan(
         None,
         "--provider",
         "-p",
-        help="LLM provider to use (openai, gemini, anthropic/claude, ollama, generic, skene)",
+        help="LLM provider to use (codex, openai, gemini, anthropic/claude, ollama, generic, skene)",
     ),
     model: str | None = typer.Option(
         None,
@@ -164,7 +164,7 @@ def plan(
                 break
 
     # If no API key and not using local provider, show sample report
-    if not rc.api_key and not rc.is_local:
+    if not rc.api_key and not rc.allows_missing_api_key:
         sample_path = context if context else Path(".")
         warning(
             "No API key provided. Showing sample growth plan preview.\n"
@@ -175,8 +175,10 @@ def plan(
         return
 
     resolved_api_key = rc.api_key
-    if not resolved_api_key:
+    if not resolved_api_key and rc.is_local:
         resolved_api_key = rc.provider  # Dummy key for local server
+    elif not resolved_api_key and rc.allows_missing_api_key:
+        resolved_api_key = ""
 
     # Handle output path: if it's a directory, append default filename
     if output.is_absolute():

--- a/src/skene/cli/config_manager.py
+++ b/src/skene/cli/config_manager.py
@@ -27,6 +27,12 @@ def _set_config_permissions(config_path: Path) -> None:
 def get_provider_models(provider: str) -> list[str]:
     """Get list of recommended models for a provider (up to 5)."""
     models_by_provider = {
+        "codex": [
+            "auto",
+            "gpt-5.4",
+            "gpt-5.3-codex",
+            "gpt-5.2-codex",
+        ],
         "openai": [
             "gpt-5.2",
             "gpt-4o",
@@ -177,6 +183,7 @@ def interactive_config_setup() -> tuple[Path, str, str, str, str | None]:
     console.print()
     providers = [
         ("skene", "Skene"),
+        ("codex", "Codex"),
         ("openai", "OpenAI"),
         ("gemini", "Google Gemini"),
         ("anthropic", "Anthropic"),
@@ -261,21 +268,25 @@ def interactive_config_setup() -> tuple[Path, str, str, str, str | None]:
         )
         base_url = base_url.strip() if base_url else None
 
-    # Ask for API key
-    console.print()
-    api_key_prompt = "[cyan]API Key[/cyan]"
-    if api_key:
-        api_key_prompt += f" (current: {api_key[:4]}...{api_key[-4:]}, press Enter to keep)"
-    api_key_prompt += ": "
+    new_api_key = ""
+    if selected_provider == "codex":
+        console.print()
+        console.print("[green]Codex uses your local Codex CLI login.[/green] Run [bold]codex login[/bold] if needed.")
+    else:
+        console.print()
+        api_key_prompt = "[cyan]API Key[/cyan]"
+        if api_key:
+            api_key_prompt += f" (current: {api_key[:4]}...{api_key[-4:]}, press Enter to keep)"
+        api_key_prompt += ": "
 
-    new_api_key = Prompt.ask(api_key_prompt, password=True, default="")
+        new_api_key = Prompt.ask(api_key_prompt, password=True, default="")
 
-    # If user pressed Enter without typing, keep existing API key
-    if not new_api_key and api_key:
-        new_api_key = api_key
-    elif not new_api_key:
-        console.print("[yellow]No API key provided. Configuration will be saved without API key.[/yellow]")
-        new_api_key = ""
+        # If user pressed Enter without typing, keep existing API key
+        if not new_api_key and api_key:
+            new_api_key = api_key
+        elif not new_api_key:
+            console.print("[yellow]No API key provided. Configuration will be saved without API key.[/yellow]")
+            new_api_key = ""
 
     return config_path, selected_provider, selected_model, new_api_key, base_url
 

--- a/src/skene/config.py
+++ b/src/skene/config.py
@@ -20,6 +20,7 @@ except ImportError:
 
 DEFAULT_MODEL_BY_PROVIDER = {
     "openai": "gpt-4o",
+    "codex": "auto",
     "gemini": "gemini-3-flash-preview",  # v1beta API requires -preview suffix
     "anthropic": "claude-sonnet-4-5",
     "ollama": "llama3.3",

--- a/src/skene/llm/factory.py
+++ b/src/skene/llm/factory.py
@@ -60,6 +60,10 @@ def create_llm_client(
             from skene.llm.providers.openai import OpenAIClient
 
             client = OpenAIClient(api_key=api_key, model_name=model_name, no_fallback=no_fallback)
+        case "codex":
+            from skene.llm.providers.codex import CodexClient
+
+            client = CodexClient(api_key=api_key, model_name=model_name)
         case "anthropic" | "claude":
             from skene.llm.providers.anthropic import AnthropicClient
 

--- a/src/skene/llm/providers/codex.py
+++ b/src/skene/llm/providers/codex.py
@@ -1,0 +1,87 @@
+"""
+Codex CLI-backed LLM client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+from typing import AsyncGenerator
+
+from pydantic import SecretStr
+
+from skene.llm.base import LLMClient
+
+
+class CodexClient(LLMClient):
+    """Use the local Codex CLI as the runtime for prompt execution."""
+
+    def __init__(self, api_key: SecretStr, model_name: str):
+        self.model_name = model_name
+        self._codex_path = shutil.which("codex")
+
+    async def _run_command(self, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        process = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        return process.returncode, stdout.decode("utf-8", errors="replace"), stderr.decode("utf-8", errors="replace")
+
+    async def _ensure_ready(self) -> None:
+        if not self._codex_path:
+            raise RuntimeError("Codex CLI is not installed or not on PATH. Install it, then run `codex login`.")
+
+        code, stdout, stderr = await self._run_command(self._codex_path, "login", "status")
+        status_text = " ".join(part for part in (stdout.strip(), stderr.strip()) if part).strip().lower()
+        if code != 0 or "not logged in" in status_text or "logged out" in status_text or "logged in" not in status_text:
+            raise RuntimeError("Codex CLI is not logged in. Run `codex login` and try again.")
+
+    async def _execute_prompt(self, prompt: str) -> str:
+        await self._ensure_ready()
+
+        with tempfile.TemporaryDirectory(prefix="skene-codex-") as temp_dir:
+            output_path = Path(temp_dir) / "last-message.txt"
+            args = [
+                self._codex_path,
+                "exec",
+                "--ephemeral",
+                "--skip-git-repo-check",
+                "--sandbox",
+                "read-only",
+                "--color",
+                "never",
+                "--output-last-message",
+                str(output_path),
+            ]
+            if self.model_name != "auto":
+                args.extend(["-m", self.model_name])
+            args.append(prompt)
+
+            code, stdout, stderr = await self._run_command(*args, cwd=temp_dir)
+            if code != 0:
+                detail = "\n".join(part for part in (stderr.strip(), stdout.strip()) if part)
+                if detail:
+                    raise RuntimeError(f"Codex CLI execution failed: {detail}")
+                raise RuntimeError("Codex CLI execution failed.")
+
+            content = output_path.read_text(encoding="utf-8").strip() if output_path.exists() else ""
+            if not content:
+                raise RuntimeError("Codex CLI returned an empty response.")
+            return content
+
+    async def generate_content_with_usage(self, prompt: str) -> tuple[str, dict[str, int] | None]:
+        return await self._execute_prompt(prompt), None
+
+    async def generate_content_stream(self, prompt: str) -> AsyncGenerator[str, None]:
+        yield await self._execute_prompt(prompt)
+
+    def get_model_name(self) -> str:
+        return self.model_name
+
+    def get_provider_name(self) -> str:
+        return "codex"

--- a/tests/test_cli/test_codex_commands.py
+++ b/tests/test_cli/test_codex_commands.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from skene.cli.app import app
+
+runner = CliRunner()
+
+
+def test_analyze_codex_bypasses_sample_preview(monkeypatch, tmp_path: Path):
+    import skene.llm
+    analyze_module = importlib.import_module("skene.cli.commands.analyze")
+
+    async def fake_run_analysis(path, output, llm, debug, product_docs, exclude_folders=None):
+        return SimpleNamespace(success=True, data={}), {"tech_stack": {}, "current_growth_features": []}
+
+    async def fake_write_growth_template(llm, manifest_data, output):
+        return {}
+
+    def fail_sample(*args, **kwargs):
+        raise AssertionError("sample preview should not run for codex")
+
+    monkeypatch.setattr(skene.llm, "create_llm_client", lambda *args, **kwargs: object())
+    monkeypatch.setattr(analyze_module, "run_analysis", fake_run_analysis)
+    monkeypatch.setattr(analyze_module, "write_growth_template", fake_write_growth_template)
+    monkeypatch.setattr(analyze_module, "show_sample_report", fail_sample)
+
+    output = tmp_path / "growth-manifest.json"
+    result = runner.invoke(app, ["analyze", str(tmp_path), "--provider", "codex", "--model", "auto", "-o", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+
+
+def test_plan_codex_bypasses_sample_preview(monkeypatch, tmp_path: Path):
+    plan_module = importlib.import_module("skene.cli.commands.plan")
+
+    async def fake_run_generate_plan(**kwargs):
+        assert kwargs["provider"] == "codex"
+        assert kwargs["api_key"] == ""
+        return "memo", {}
+
+    def fail_sample(*args, **kwargs):
+        raise AssertionError("sample preview should not run for codex")
+
+    monkeypatch.setattr(plan_module, "run_generate_plan", fake_run_generate_plan)
+    monkeypatch.setattr(plan_module, "show_sample_report", fail_sample)
+
+    output = tmp_path / "growth-plan.md"
+    result = runner.invoke(app, ["plan", "--provider", "codex", "--model", "auto", "-o", str(output)])
+
+    assert result.exit_code == 0, result.stdout
+
+
+def test_build_codex_bypasses_api_key_validation(monkeypatch, tmp_path: Path):
+    build_module = importlib.import_module("skene.cli.commands.build")
+    import skene.engine
+    import skene.feature_registry
+    import skene.growth_loops.push as push_module
+    import skene.llm
+
+    plan_path = tmp_path / "growth-plan.md"
+    plan_path.write_text("# Plan", encoding="utf-8")
+    prompt_file = tmp_path / "implementation-prompt.md"
+
+    def fake_create_llm_client(provider, api_key, model_name, **kwargs):
+        assert provider == "codex"
+        assert api_key.get_secret_value() == ""
+        assert model_name == "auto"
+        return object()
+
+    async def fake_build_prompt_with_llm(*args, **kwargs):
+        return "prompt"
+
+    monkeypatch.setattr(skene.llm, "create_llm_client", fake_create_llm_client)
+    monkeypatch.setattr(build_module, "extract_technical_execution", lambda path: {"overview": "Overview"})
+    monkeypatch.setattr(build_module, "build_prompt_with_llm", fake_build_prompt_with_llm)
+    monkeypatch.setattr(build_module, "save_prompt_to_file", lambda prompt, output_dir: prompt_file)
+
+    monkeypatch.setattr(skene.engine, "ensure_engine_dir", lambda project_root: None)
+    monkeypatch.setattr(skene.engine, "default_engine_path", lambda project_root: project_root / "skene" / "engine.yaml")
+    monkeypatch.setattr(skene.engine, "load_engine_document", lambda *args, **kwargs: SimpleNamespace(features=[]))
+    monkeypatch.setattr(skene.engine, "generate_engine_delta_with_llm", fake_build_prompt_with_llm)
+    monkeypatch.setattr(skene.engine, "merge_engine_documents", lambda existing, delta: existing)
+    monkeypatch.setattr(skene.engine, "write_engine_document", lambda *args, **kwargs: None)
+    monkeypatch.setattr(skene.engine, "engine_features_to_loop_definitions", lambda engine_doc: [])
+
+    monkeypatch.setattr(skene.feature_registry, "load_features_for_build", lambda base_output_dir: [])
+    monkeypatch.setattr(skene.feature_registry, "get_registry_path_for_output", lambda output: tmp_path / "feature-registry.json")
+    monkeypatch.setattr(skene.feature_registry, "upsert_registry_from_engine", lambda engine_doc, registry_path: None)
+
+    monkeypatch.setattr(push_module, "ensure_base_schema_migration", lambda project_root: tmp_path / "schema.sql")
+    monkeypatch.setattr(push_module, "build_loops_to_supabase", lambda loop_defs, project_root: tmp_path / "loops.sql")
+
+    result = runner.invoke(
+        app,
+        ["build", "--provider", "codex", "--model", "auto", "--plan", str(plan_path), "--target", "file"],
+    )
+
+    assert result.exit_code == 0, result.stdout

--- a/tests/test_cli/test_resolve_cli_config.py
+++ b/tests/test_cli/test_resolve_cli_config.py
@@ -75,3 +75,25 @@ class TestResolveCliConfig:
 
         rc = resolve_cli_config()
         assert rc.base_url == "https://example.com/v1"
+
+    def test_codex_defaults_to_auto_model(self, monkeypatch):
+        """Uses the codex default model when none is configured."""
+        cfg = Config()
+        cfg.set("provider", "codex")
+        monkeypatch.setattr(_app, "load_config", lambda: cfg)
+
+        rc = resolve_cli_config()
+        assert rc.provider == "codex"
+        assert rc.model == "auto"
+
+    def test_codex_allows_missing_api_key(self, monkeypatch):
+        """Treats codex as runtime-authenticated without marking it local."""
+        cfg = Config()
+        cfg.set("provider", "codex")
+        cfg.set("model", "auto")
+        monkeypatch.setattr(_app, "load_config", lambda: cfg)
+
+        rc = resolve_cli_config()
+        assert rc.api_key is None
+        assert rc.is_local is False
+        assert rc.allows_missing_api_key is True

--- a/tests/test_llm/test_codex_provider.py
+++ b/tests/test_llm/test_codex_provider.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pydantic import SecretStr
+
+from skene.llm.factory import create_llm_client
+from skene.llm.providers.codex import CodexClient
+
+
+def test_factory_creates_codex_client():
+    client = create_llm_client(
+        provider="codex",
+        api_key=SecretStr(""),
+        model_name="auto",
+    )
+    assert isinstance(client, CodexClient)
+    assert client.get_provider_name() == "codex"
+    assert client.get_model_name() == "auto"
+
+
+class _FakeProcess:
+    def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: str = "", on_communicate=None):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._on_communicate = on_communicate
+
+    async def communicate(self):
+        if self._on_communicate is not None:
+            self._on_communicate()
+        return self._stdout.encode(), self._stderr.encode()
+
+
+@pytest.mark.asyncio
+async def test_codex_client_omits_model_flag_for_auto(monkeypatch):
+    from skene.llm.providers import codex as codex_module
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_exec(*args, cwd=None, stdout=None, stderr=None):
+        calls.append({"args": args, "cwd": cwd})
+        if args[:3] == ("/usr/bin/codex", "login", "status"):
+            return _FakeProcess(returncode=0, stdout="Logged in using ChatGPT")
+
+        output_idx = args.index("--output-last-message") + 1
+        output_path = Path(args[output_idx])
+        return _FakeProcess(returncode=0, on_communicate=lambda: output_path.write_text("codex reply", encoding="utf-8"))
+
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr(codex_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    client = CodexClient(api_key=SecretStr(""), model_name="auto")
+    content, usage = await client.generate_content_with_usage("hello")
+    stream_chunks = [chunk async for chunk in client.generate_content_stream("hello again")]
+
+    exec_call = calls[1]["args"]
+    assert exec_call[0:7] == (
+        "/usr/bin/codex",
+        "exec",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--color",
+    )
+    assert "-m" not in exec_call
+    assert content == "codex reply"
+    assert usage is None
+    assert stream_chunks == ["codex reply"]
+    assert calls[1]["cwd"] != calls[2]["cwd"]
+
+
+@pytest.mark.asyncio
+async def test_codex_client_passes_explicit_model(monkeypatch):
+    from skene.llm.providers import codex as codex_module
+
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_exec(*args, cwd=None, stdout=None, stderr=None):
+        calls.append(args)
+        if args[:3] == ("/usr/bin/codex", "login", "status"):
+            return _FakeProcess(returncode=0, stdout="Logged in using ChatGPT")
+
+        output_idx = args.index("--output-last-message") + 1
+        output_path = Path(args[output_idx])
+        return _FakeProcess(returncode=0, on_communicate=lambda: output_path.write_text("ok", encoding="utf-8"))
+
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr(codex_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    client = CodexClient(api_key=SecretStr(""), model_name="gpt-5.4")
+    await client.generate_content_with_usage("hello")
+
+    exec_call = calls[1]
+    model_idx = exec_call.index("-m")
+    assert exec_call[model_idx : model_idx + 2] == ("-m", "gpt-5.4")
+
+
+@pytest.mark.asyncio
+async def test_codex_client_fails_when_binary_missing(monkeypatch):
+    from skene.llm.providers import codex as codex_module
+
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _: None)
+
+    client = CodexClient(api_key=SecretStr(""), model_name="auto")
+    with pytest.raises(RuntimeError, match="Codex CLI is not installed"):
+        await client.generate_content_with_usage("hello")
+
+
+@pytest.mark.asyncio
+async def test_codex_client_fails_when_logged_out(monkeypatch):
+    from skene.llm.providers import codex as codex_module
+
+    async def fake_exec(*args, cwd=None, stdout=None, stderr=None):
+        return _FakeProcess(returncode=0, stdout="Not logged in")
+
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr(codex_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    client = CodexClient(api_key=SecretStr(""), model_name="auto")
+    with pytest.raises(RuntimeError, match="Run `codex login`"):
+        await client.generate_content_with_usage("hello")
+
+
+@pytest.mark.asyncio
+async def test_codex_client_fails_on_non_zero_exit(monkeypatch):
+    from skene.llm.providers import codex as codex_module
+
+    async def fake_exec(*args, cwd=None, stdout=None, stderr=None):
+        if args[:3] == ("/usr/bin/codex", "login", "status"):
+            return _FakeProcess(returncode=0, stdout="Logged in using ChatGPT")
+        return _FakeProcess(returncode=1, stderr="boom")
+
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr(codex_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    client = CodexClient(api_key=SecretStr(""), model_name="auto")
+    with pytest.raises(RuntimeError, match="boom"):
+        await client.generate_content_with_usage("hello")
+
+
+@pytest.mark.asyncio
+async def test_codex_client_fails_on_empty_output(monkeypatch):
+    from skene.llm.providers import codex as codex_module
+
+    async def fake_exec(*args, cwd=None, stdout=None, stderr=None):
+        if args[:3] == ("/usr/bin/codex", "login", "status"):
+            return _FakeProcess(returncode=0, stdout="Logged in using ChatGPT")
+        return _FakeProcess(returncode=0)
+
+    monkeypatch.setattr(codex_module.shutil, "which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr(codex_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    client = CodexClient(api_key=SecretStr(""), model_name="auto")
+    with pytest.raises(RuntimeError, match="empty response"):
+        await client.generate_content_with_usage("hello")

--- a/tui/internal/services/auth/codex.go
+++ b/tui/internal/services/auth/codex.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// CodexStatus describes whether the local Codex CLI is installed and logged in.
+type CodexStatus struct {
+	Installed bool
+	LoggedIn  bool
+	Message   string
+}
+
+// CheckCodexStatus verifies that the local Codex CLI exists and is authenticated.
+func CheckCodexStatus() CodexStatus {
+	if _, err := exec.LookPath("codex"); err != nil {
+		return CodexStatus{
+			Installed: false,
+			LoggedIn:  false,
+			Message:   "Codex CLI is not installed. Install it, then run `codex login`.",
+		}
+	}
+
+	out, err := exec.Command("codex", "login", "status").CombinedOutput()
+	statusText := strings.TrimSpace(string(out))
+	lower := strings.ToLower(statusText)
+
+	if err != nil {
+		return CodexStatus{
+			Installed: true,
+			LoggedIn:  false,
+			Message:   "Codex CLI is not logged in. Run `codex login` and try again.",
+		}
+	}
+
+	if strings.Contains(lower, "not logged in") || strings.Contains(lower, "logged out") {
+		return CodexStatus{
+			Installed: true,
+			LoggedIn:  false,
+			Message:   "Codex CLI is not logged in. Run `codex login` and try again.",
+		}
+	}
+
+	if statusText == "" {
+		statusText = "Codex CLI login is ready."
+	}
+
+	return CodexStatus{
+		Installed: true,
+		LoggedIn:  true,
+		Message:   statusText,
+	}
+}

--- a/tui/internal/services/config/manager.go
+++ b/tui/internal/services/config/manager.go
@@ -185,6 +185,8 @@ func (m *Manager) writeConfigToPath(path string) error {
 
 	if m.Config.APIKey != "" {
 		existing["api_key"] = m.Config.APIKey
+	} else {
+		delete(existing, "api_key")
 	}
 	if m.Config.Provider != "" {
 		existing["provider"] = m.Config.Provider
@@ -194,6 +196,8 @@ func (m *Manager) writeConfigToPath(path string) error {
 	}
 	if m.Config.BaseURL != "" {
 		existing["base_url"] = m.Config.BaseURL
+	} else {
+		delete(existing, "base_url")
 	}
 	if m.Config.OutputDir != "" {
 		existing["output_dir"] = m.Config.OutputDir
@@ -228,6 +232,12 @@ func (m *Manager) SetAPIKey(key string) {
 	m.Config.APIKey = key
 }
 
+// ClearLLMCredentials removes provider-specific credentials that should not carry across providers.
+func (m *Manager) ClearLLMCredentials() {
+	m.Config.APIKey = ""
+	m.Config.BaseURL = ""
+}
+
 // SetProjectDir sets the project directory
 func (m *Manager) SetProjectDir(dir string) {
 	m.Config.ProjectDir = dir
@@ -250,6 +260,12 @@ func (m *Manager) SetUpstreamAPIKey(key string) {
 
 // GetMaskedAPIKey returns masked API key for display
 func (m *Manager) GetMaskedAPIKey() string {
+	if strings.EqualFold(m.Config.Provider, "codex") {
+		return "ChatGPT login"
+	}
+	if m.Config.APIKey == "" {
+		return "Not set"
+	}
 	if len(m.Config.APIKey) <= 8 {
 		return "****"
 	}
@@ -258,7 +274,13 @@ func (m *Manager) GetMaskedAPIKey() string {
 
 // HasValidConfig checks if config has minimum required values
 func (m *Manager) HasValidConfig() bool {
-	return m.Config.Provider != "" && m.Config.Model != "" && m.Config.APIKey != ""
+	if m.Config.Provider == "" || m.Config.Model == "" {
+		return false
+	}
+	if strings.EqualFold(m.Config.Provider, "codex") {
+		return true
+	}
+	return m.Config.APIKey != ""
 }
 
 // GetShortenedPath returns a shortened path for display
@@ -359,6 +381,18 @@ func GetProviders() []Provider {
 			AuthURL:     constants.SkeneAuthURL,
 			Models: []Model{
 				{ID: constants.SkeneDefaultModel, Name: "skene", Description: "Growth analysis model"},
+			},
+		},
+		{
+			ID:          "codex",
+			Name:        "Codex",
+			Description: "Use the local Codex CLI with ChatGPT sign-in",
+			RequiresKey: false,
+			Models: []Model{
+				{ID: "auto", Name: "Auto", Description: "Use Codex CLI defaults"},
+				{ID: "gpt-5.4", Name: "GPT-5.4", Description: "Most capable general-purpose model"},
+				{ID: "gpt-5.3-codex", Name: "GPT-5.3-Codex", Description: "Flagship model for agentic coding"},
+				{ID: "gpt-5.2-codex", Name: "GPT-5.2-Codex", Description: "Strong long-horizon coding model"},
 			},
 		},
 		{

--- a/tui/internal/services/config/manager_test.go
+++ b/tui/internal/services/config/manager_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetProvidersIncludesCodex(t *testing.T) {
+	provider := GetProviderByID("codex")
+	if provider == nil {
+		t.Fatalf("expected codex provider to be registered")
+	}
+	if provider.RequiresKey {
+		t.Fatalf("expected codex provider to avoid stored API keys")
+	}
+	if len(provider.Models) == 0 || provider.Models[0].ID != "auto" {
+		t.Fatalf("expected codex provider to default to auto model")
+	}
+}
+
+func TestHasValidConfigAllowsCodexWithoutAPIKey(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+	mgr.Config.Provider = "codex"
+	mgr.Config.Model = "auto"
+	mgr.Config.APIKey = ""
+
+	if !mgr.HasValidConfig() {
+		t.Fatalf("expected codex config without api key to be valid")
+	}
+}
+
+func TestSaveUserConfigRemovesClearedLLMCredentials(t *testing.T) {
+	tempDir := t.TempDir()
+	mgr := NewManager(tempDir)
+	mgr.UserConfigPath = tempDir + "/config"
+
+	initial := strings.Join([]string{
+		`api_key = "old-key"`,
+		`provider = "openai"`,
+		`model = "gpt-5.4"`,
+		`base_url = "https://example.com/v1"`,
+		`output_dir = "./skene-context"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(mgr.UserConfigPath, []byte(initial), 0600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	mgr.Config.Provider = "codex"
+	mgr.Config.Model = "auto"
+	mgr.Config.OutputDir = "./skene-context"
+	mgr.ClearLLMCredentials()
+
+	if err := mgr.SaveUserConfig(); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	data, err := os.ReadFile(mgr.UserConfigPath)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "api_key") {
+		t.Fatalf("expected api_key to be removed, got:\n%s", content)
+	}
+	if strings.Contains(content, "base_url") {
+		t.Fatalf("expected base_url to be removed, got:\n%s", content)
+	}
+	if !strings.Contains(content, `provider = "codex"`) {
+		t.Fatalf("expected provider to remain, got:\n%s", content)
+	}
+	if !strings.Contains(content, `model = "auto"`) {
+		t.Fatalf("expected model to remain, got:\n%s", content)
+	}
+
+	reloaded, err := mgr.loadConfigFile(mgr.UserConfigPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if reloaded.APIKey != "" {
+		t.Fatalf("expected API key to stay cleared, got %q", reloaded.APIKey)
+	}
+	if reloaded.BaseURL != "" {
+		t.Fatalf("expected base URL to stay cleared, got %q", reloaded.BaseURL)
+	}
+}

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -39,6 +39,7 @@ const (
 	StateProviderSelect                 // AI provider selection
 	StateModelSelect                    // Model selection for chosen provider
 	StateAuth                           // Skene magic link authentication
+	StateCodexAuth                      // Codex CLI login status
 	StateAPIKey                         // Manual API key entry
 	StateLocalModel                     // Local model detection (Ollama/LM Studio)
 	StateProjectDir                     // Project directory selection
@@ -102,6 +103,11 @@ type AuthCallbackMsg struct {
 	Error    error
 }
 
+// CodexAuthStatusMsg is sent when the local Codex CLI auth status has been checked.
+type CodexAuthStatusMsg struct {
+	Status auth.CodexStatus
+}
+
 // VersionCheckMsg is sent when the background version check completes
 type VersionCheckMsg struct {
 	Result *versioncheck.Result
@@ -134,11 +140,12 @@ type App struct {
 	selectedModel    *config.Model
 
 	// Views
-	welcomeView      *views.WelcomeView
-	configCheckView  *views.ConfigCheckView
-	providerView     *views.ProviderView
+	welcomeView        *views.WelcomeView
+	configCheckView    *views.ConfigCheckView
+	providerView       *views.ProviderView
 	modelView          *views.ModelView
 	authView           *views.AuthView
+	codexAuthView      *views.CodexAuthView
 	apiKeyView         *views.APIKeyView
 	localModelView     *views.LocalModelView
 	projectDirView     *views.ProjectDirView
@@ -161,6 +168,7 @@ type App struct {
 	// Cancellation for running processes
 	cancelFunc      context.CancelFunc
 	analyzingOrigin AppState // state to return to when cancelling/failing
+	codexAuthReturn AppState // state to return to when backing out of Codex auth
 
 	// Auth state
 	authCountdown  int
@@ -175,6 +183,8 @@ type App struct {
 	// Program reference for sending messages from background tasks
 	program *tea.Program
 }
+
+var checkCodexStatus = auth.CheckCodexStatus
 
 // ═══════════════════════════════════════════════════════════════════
 // INITIALIZATION
@@ -275,6 +285,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if a.state == StateAuth && a.authView != nil {
 			a.authView.TickSpinner()
+		}
+		if a.state == StateCodexAuth && a.codexAuthView != nil {
+			a.codexAuthView.TickSpinner()
 		}
 		if a.state == StateAPIKey && a.apiKeyView != nil {
 			a.apiKeyView.TickSpinner()
@@ -436,6 +449,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}))
 		}
 
+	case CodexAuthStatusMsg:
+		if a.codexAuthView != nil {
+			a.codexAuthView.SetStatus(msg.Status)
+		}
+		if msg.Status.LoggedIn {
+			a.transitionToProjectDir()
+		}
+
 	case authVerifiedMsg:
 		// Show success state after the fake verification delay
 		if a.authView != nil {
@@ -495,6 +516,8 @@ func (a *App) handleKeyPress(msg tea.KeyMsg) tea.Cmd {
 		return a.handleModelKeys(msg)
 	case StateAuth:
 		return a.handleAuthKeys(key)
+	case StateCodexAuth:
+		return a.handleCodexAuthKeys(key)
 	case StateAPIKey:
 		return a.handleAPIKeyKeys(msg)
 	case StateLocalModel:
@@ -563,6 +586,9 @@ func (a *App) handleConfigCheckKeys(msg tea.KeyMsg) tea.Cmd {
 		a.configCheckView.HandleDown()
 	case "enter":
 		if a.configCheckView.SelectedUseExisting() {
+			if a.selectedProvider != nil && a.selectedProvider.ID == "codex" {
+				return a.startCodexAuthCheck(StateConfigCheck)
+			}
 			a.transitionToProjectDir()
 		} else {
 			a.state = StateProviderSelect
@@ -599,7 +625,7 @@ func (a *App) handleModelKeys(msg tea.KeyMsg) tea.Cmd {
 	case "down", "j":
 		a.modelView.HandleDown()
 	case "enter":
-		a.selectModel()
+		return a.selectModel()
 	case "esc":
 		a.state = StateProviderSelect
 	}
@@ -650,6 +676,16 @@ func (a *App) handleAPIKeyKeys(msg tea.KeyMsg) tea.Cmd {
 		a.navigateBackFromAPIKey()
 	default:
 		a.apiKeyView.Update(msg)
+	}
+	return nil
+}
+
+func (a *App) handleCodexAuthKeys(key string) tea.Cmd {
+	switch key {
+	case "enter", "r":
+		return a.checkCodexAuthCmd()
+	case "esc":
+		a.state = a.codexAuthReturn
 	}
 	return nil
 }
@@ -992,6 +1028,9 @@ func (a *App) selectProvider() tea.Cmd {
 
 	a.selectedProvider = provider
 	a.configMgr.SetProvider(provider.ID)
+	if provider.ID == "codex" {
+		a.configMgr.ClearLLMCredentials()
+	}
 
 	// Branch based on provider type
 	if provider.ID == "skene" {
@@ -1048,23 +1087,46 @@ func (a *App) selectProvider() tea.Cmd {
 	return nil
 }
 
-func (a *App) selectModel() {
+func (a *App) selectModel() tea.Cmd {
 	model := a.modelView.GetSelectedModel()
 	if model == nil {
-		return
+		return nil
 	}
 
 	a.selectedModel = model
 	a.configMgr.SetModel(model.ID)
 
+	if a.selectedProvider != nil && a.selectedProvider.ID == "codex" {
+		return a.startCodexAuthCheck(StateModelSelect)
+	}
+
 	// Go to API key entry
 	a.transitionToAPIKey()
+	return nil
 }
 
 func (a *App) transitionToAPIKey() {
 	a.apiKeyView = views.NewAPIKeyView(a.selectedProvider, a.selectedModel)
 	a.apiKeyView.SetSize(a.width, a.height)
 	a.state = StateAPIKey
+}
+
+func (a *App) startCodexAuthCheck(returnState AppState) tea.Cmd {
+	providerName := "Codex"
+	modelName := ""
+	if a.selectedProvider != nil {
+		providerName = a.selectedProvider.Name
+	}
+	if a.selectedModel != nil {
+		modelName = a.selectedModel.Name
+	}
+
+	a.configMgr.ClearLLMCredentials()
+	a.codexAuthReturn = returnState
+	a.codexAuthView = views.NewCodexAuthView(providerName, modelName)
+	a.codexAuthView.SetSize(a.width, a.height)
+	a.state = StateCodexAuth
+	return a.checkCodexAuthCmd()
 }
 
 func (a *App) transitionToProjectDir() {
@@ -1142,6 +1204,8 @@ func (a *App) navigateBackFromAPIKey() {
 func (a *App) navigateBackFromProjectDir() {
 	if a.selectedProvider != nil && a.selectedProvider.IsLocal {
 		a.state = StateLocalModel
+	} else if a.selectedProvider != nil && a.selectedProvider.ID == "codex" && a.codexAuthView != nil {
+		a.state = StateCodexAuth
 	} else if a.apiKeyView != nil {
 		a.state = StateAPIKey
 	} else if a.configCheckView != nil {
@@ -1320,7 +1384,6 @@ func (a *App) runEngineCommand(title string, command string) tea.Cmd {
 	}
 }
 
-
 func (a *App) waitForAuthCallback() tea.Cmd {
 	server := a.callbackServer
 	if server == nil {
@@ -1375,6 +1438,15 @@ func (a *App) detectLocalModels() tea.Cmd {
 	}
 }
 
+func (a *App) checkCodexAuthCmd() tea.Cmd {
+	if a.codexAuthView != nil {
+		a.codexAuthView.SetChecking(true)
+	}
+	return func() tea.Msg {
+		return CodexAuthStatusMsg{Status: checkCodexStatus()}
+	}
+}
+
 func (a *App) showError(err *views.ErrorInfo) {
 	a.prevState = a.state
 	a.currentError = err
@@ -1402,6 +1474,9 @@ func (a *App) updateViewSizes() {
 	}
 	if a.authView != nil {
 		a.authView.SetSize(a.width, a.height)
+	}
+	if a.codexAuthView != nil {
+		a.codexAuthView.SetSize(a.width, a.height)
 	}
 	if a.apiKeyView != nil {
 		a.apiKeyView.SetSize(a.width, a.height)
@@ -1456,6 +1531,10 @@ func (a *App) View() string {
 	case StateAuth:
 		if a.authView != nil {
 			content = a.authView.Render()
+		}
+	case StateCodexAuth:
+		if a.codexAuthView != nil {
+			content = a.codexAuthView.Render()
 		}
 	case StateAPIKey:
 		if a.apiKeyView != nil {
@@ -1542,6 +1621,10 @@ func (a *App) getCurrentHelpItems() []components.HelpItem {
 	case StateAuth:
 		if a.authView != nil {
 			return a.authView.GetHelpItems()
+		}
+	case StateCodexAuth:
+		if a.codexAuthView != nil {
+			return a.codexAuthView.GetHelpItems()
 		}
 	case StateAPIKey:
 		if a.apiKeyView != nil {

--- a/tui/internal/tui/app_codex_test.go
+++ b/tui/internal/tui/app_codex_test.go
@@ -1,0 +1,158 @@
+package tui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"skene/internal/services/auth"
+	"skene/internal/services/config"
+)
+
+func newTestApp(t *testing.T) *App {
+	t.Helper()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	tmpDir := t.TempDir()
+	app.configMgr.ProjectConfigPath = filepath.Join(tmpDir, ".skene.config")
+	app.configMgr.UserConfigPath = filepath.Join(tmpDir, "config")
+	return app
+}
+
+func TestCodexAuthFlowStaysOnAuthViewWhenLoggedOut(t *testing.T) {
+	app := newTestApp(t)
+	provider := config.GetProviderByID("codex")
+	if provider == nil {
+		t.Fatalf("expected codex provider")
+	}
+	app.selectedProvider = provider
+	app.selectedModel = &provider.Models[0]
+	app.configMgr.SetProvider(provider.ID)
+	app.configMgr.SetModel(app.selectedModel.ID)
+
+	original := checkCodexStatus
+	checkCodexStatus = func() auth.CodexStatus {
+		return auth.CodexStatus{
+			Installed: true,
+			LoggedIn:  false,
+			Message:   "Codex CLI is not logged in. Run `codex login` and try again.",
+		}
+	}
+	defer func() { checkCodexStatus = original }()
+
+	cmd := app.startCodexAuthCheck(StateModelSelect)
+	msg := cmd()
+	updatedModel, _ := app.Update(msg)
+	updated := updatedModel.(*App)
+
+	if updated.state != StateCodexAuth {
+		t.Fatalf("expected state %v, got %v", StateCodexAuth, updated.state)
+	}
+	if updated.codexAuthView == nil {
+		t.Fatalf("expected codex auth view to be active")
+	}
+	if updated.projectDirView != nil {
+		t.Fatalf("did not expect project dir view while logged out")
+	}
+}
+
+func TestCodexAuthFlowTransitionsToProjectDirWhenLoggedIn(t *testing.T) {
+	app := newTestApp(t)
+	provider := config.GetProviderByID("codex")
+	if provider == nil {
+		t.Fatalf("expected codex provider")
+	}
+	app.selectedProvider = provider
+	app.selectedModel = &provider.Models[0]
+	app.configMgr.SetProvider(provider.ID)
+	app.configMgr.SetModel(app.selectedModel.ID)
+
+	original := checkCodexStatus
+	checkCodexStatus = func() auth.CodexStatus {
+		return auth.CodexStatus{
+			Installed: true,
+			LoggedIn:  true,
+			Message:   "Logged in using ChatGPT",
+		}
+	}
+	defer func() { checkCodexStatus = original }()
+
+	cmd := app.startCodexAuthCheck(StateModelSelect)
+	msg := cmd()
+	updatedModel, _ := app.Update(msg)
+	updated := updatedModel.(*App)
+
+	if updated.state != StateProjectDir {
+		t.Fatalf("expected state %v, got %v", StateProjectDir, updated.state)
+	}
+	if updated.projectDirView == nil {
+		t.Fatalf("expected project dir view to be active")
+	}
+}
+
+func TestCodexAuthEscReturnsToConfigCheckWhenStartedFromExistingConfig(t *testing.T) {
+	app := newTestApp(t)
+	provider := config.GetProviderByID("codex")
+	if provider == nil {
+		t.Fatalf("expected codex provider")
+	}
+	app.selectedProvider = provider
+	app.selectedModel = &provider.Models[0]
+	app.configMgr.SetProvider(provider.ID)
+	app.configMgr.SetModel(app.selectedModel.ID)
+
+	original := checkCodexStatus
+	checkCodexStatus = func() auth.CodexStatus {
+		return auth.CodexStatus{
+			Installed: true,
+			LoggedIn:  false,
+			Message:   "Codex CLI is not logged in. Run `codex login` and try again.",
+		}
+	}
+	defer func() { checkCodexStatus = original }()
+
+	cmd := app.startCodexAuthCheck(StateConfigCheck)
+	msg := cmd()
+	updatedModel, _ := app.Update(msg)
+	updated := updatedModel.(*App)
+
+	updated.handleCodexAuthKeys("esc")
+
+	if updated.state != StateConfigCheck {
+		t.Fatalf("expected state %v, got %v", StateConfigCheck, updated.state)
+	}
+}
+
+func TestCodexAuthEscReturnsToModelSelectWhenStartedFromModelSelect(t *testing.T) {
+	app := newTestApp(t)
+	provider := config.GetProviderByID("codex")
+	if provider == nil {
+		t.Fatalf("expected codex provider")
+	}
+	app.selectedProvider = provider
+	app.selectedModel = &provider.Models[0]
+	app.configMgr.SetProvider(provider.ID)
+	app.configMgr.SetModel(app.selectedModel.ID)
+
+	original := checkCodexStatus
+	checkCodexStatus = func() auth.CodexStatus {
+		return auth.CodexStatus{
+			Installed: true,
+			LoggedIn:  false,
+			Message:   "Codex CLI is not logged in. Run `codex login` and try again.",
+		}
+	}
+	defer func() { checkCodexStatus = original }()
+
+	cmd := app.startCodexAuthCheck(StateModelSelect)
+	msg := cmd()
+	updatedModel, _ := app.Update(msg)
+	updated := updatedModel.(*App)
+
+	updated.handleCodexAuthKeys("esc")
+
+	if updated.state != StateModelSelect {
+		t.Fatalf("expected state %v, got %v", StateModelSelect, updated.state)
+	}
+}

--- a/tui/internal/tui/views/codex_auth.go
+++ b/tui/internal/tui/views/codex_auth.go
@@ -1,0 +1,170 @@
+package views
+
+import (
+	"skene/internal/constants"
+	"skene/internal/services/auth"
+	"skene/internal/tui/components"
+	"skene/internal/tui/styles"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// CodexAuthView shows local Codex CLI login status.
+type CodexAuthView struct {
+	width        int
+	height       int
+	providerName string
+	modelName    string
+	checking     bool
+	status       auth.CodexStatus
+	header       *components.WizardHeader
+	spinner      *components.Spinner
+}
+
+// NewCodexAuthView creates a new Codex auth status view.
+func NewCodexAuthView(providerName, modelName string) *CodexAuthView {
+	return &CodexAuthView{
+		providerName: providerName,
+		modelName:    modelName,
+		checking:     true,
+		header:       components.NewWizardHeader(2, constants.StepNameAuthentication),
+		spinner:      components.NewSpinner(),
+	}
+}
+
+// SetSize updates dimensions.
+func (v *CodexAuthView) SetSize(width, height int) {
+	v.width = width
+	v.height = height
+	v.header.SetWidth(width)
+}
+
+// SetChecking updates the pending state.
+func (v *CodexAuthView) SetChecking(checking bool) {
+	v.checking = checking
+}
+
+// SetStatus applies a resolved Codex status.
+func (v *CodexAuthView) SetStatus(status auth.CodexStatus) {
+	v.status = status
+	v.checking = false
+}
+
+// TickSpinner advances the spinner animation.
+func (v *CodexAuthView) TickSpinner() {
+	v.spinner.Tick()
+}
+
+// Render draws the Codex auth status view.
+func (v *CodexAuthView) Render() string {
+	sectionWidth := v.width - 20
+	if sectionWidth < 60 {
+		sectionWidth = 60
+	}
+	if sectionWidth > 80 {
+		sectionWidth = 80
+	}
+
+	wizHeader := lipgloss.NewStyle().Width(sectionWidth).Render(v.header.Render())
+	contentSection := v.renderContent(sectionWidth)
+
+	helpItems := []components.HelpItem{
+		{Key: constants.HelpKeyEnter, Desc: constants.HelpDescRetry},
+		{Key: constants.HelpKeyR, Desc: constants.HelpDescRetry},
+		{Key: constants.HelpKeyEsc, Desc: constants.HelpDescGoBack},
+		{Key: constants.HelpKeyCtrlC, Desc: constants.HelpDescQuit},
+	}
+	if v.checking {
+		helpItems = []components.HelpItem{
+			{Key: constants.HelpKeyEsc, Desc: constants.HelpDescGoBack},
+			{Key: constants.HelpKeyCtrlC, Desc: constants.HelpDescQuit},
+		}
+	}
+
+	footer := lipgloss.NewStyle().
+		Width(v.width).
+		Align(lipgloss.Center).
+		Render(components.FooterHelp(helpItems, v.width))
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		wizHeader,
+		"",
+		contentSection,
+	)
+
+	padded := lipgloss.NewStyle().PaddingTop(2).Render(content)
+
+	centered := lipgloss.Place(
+		v.width,
+		v.height-3,
+		lipgloss.Center,
+		lipgloss.Top,
+		padded,
+	)
+
+	return centered + "\n" + footer
+}
+
+func (v *CodexAuthView) renderContent(width int) string {
+	header := styles.SectionHeader.Render("Codex Login")
+	infoRows := []string{
+		styles.Label.Render("Provider: ") + styles.Body.Render(v.providerName),
+	}
+	if v.modelName != "" {
+		infoRows = append(infoRows, styles.Label.Render("Model:    ")+styles.Body.Render(v.modelName))
+	}
+
+	var statusBlock string
+	switch {
+	case v.checking:
+		statusBlock = lipgloss.JoinVertical(
+			lipgloss.Left,
+			v.spinner.SpinnerWithText("Checking local Codex login..."),
+			styles.Muted.Render("Skene will use your existing Codex CLI session."),
+		)
+	case v.status.LoggedIn:
+		statusBlock = lipgloss.JoinVertical(
+			lipgloss.Left,
+			styles.SuccessText.Render("✓ Codex CLI is ready"),
+			styles.Muted.Render(v.status.Message),
+		)
+	default:
+		setupHint := "Run `codex login`, then press Enter or r to retry."
+		if !v.status.Installed {
+			setupHint = "Install the Codex CLI, run `codex login`, then press Enter or r to retry."
+		}
+		statusBlock = lipgloss.JoinVertical(
+			lipgloss.Left,
+			lipgloss.NewStyle().Foreground(styles.ErrorColor).Render("✗ "+v.status.Message),
+			styles.Muted.Render(setupHint),
+		)
+	}
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		header,
+		"",
+		lipgloss.JoinVertical(lipgloss.Left, infoRows...),
+		"",
+		statusBlock,
+	)
+
+	return styles.Box.Width(width).Render(content)
+}
+
+// GetHelpItems returns context-specific help.
+func (v *CodexAuthView) GetHelpItems() []components.HelpItem {
+	if v.checking {
+		return []components.HelpItem{
+			{Key: constants.HelpKeyEsc, Desc: constants.HelpDescGoBack},
+			{Key: constants.HelpKeyCtrlC, Desc: constants.HelpDescQuit},
+		}
+	}
+	return []components.HelpItem{
+		{Key: constants.HelpKeyEnter, Desc: constants.HelpDescRetry},
+		{Key: constants.HelpKeyR, Desc: constants.HelpDescRetry},
+		{Key: constants.HelpKeyEsc, Desc: constants.HelpDescGoBack},
+		{Key: constants.HelpKeyCtrlC, Desc: constants.HelpDescQuit},
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated `codex` provider for the Python CLI and Go TUI
- route Codex requests through the local Codex CLI instead of stored API keys
- add Codex-specific auth/status flows and regression coverage across CLI and TUI

## Testing
- `./.venv/bin/python -m pytest`
- `go test ./...`