### PR TITLE
TUI: surface "Deploy to Skene Cloud" as primary button

### DIFF
--- a/tui/internal/constants/strings.go
+++ b/tui/internal/constants/strings.go
@@ -195,6 +195,7 @@ const (
 	ProjectDirExistingQ      = "What would you like to do?"
 	ProjectDirViewAnalysis       = "View Journey"
 	ProjectDirRerunAnalysis      = "Re-run Analysis"
+	ProjectDirDeployToCloud      = "Deploy to Skene Cloud"
 	ProjectDirRunAnalysis        = "Analyse Journey"
 	ProjectDirRunCodebaseAnalysis = "Analyse Codebase"
 

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -747,6 +747,8 @@ func (a *App) handleProjectDirKeys(msg tea.KeyMsg) tea.Cmd {
 				cmd := a.startCodebaseAnalysis()
 				a.analyzingOrigin = StateProjectDir
 				return cmd
+			case constants.ProjectDirDeployToCloud:
+				return a.startPushFlow(StateProjectDir)
 			}
 		case "n":
 			pd := a.projectDirView.GetProjectDir()

--- a/tui/internal/tui/views/project_dir.go
+++ b/tui/internal/tui/views/project_dir.go
@@ -319,17 +319,18 @@ func existingBundleDir(projectDir string) string {
 }
 
 // buildExistingButtons creates the button group based on which files exist.
-// "View Journey" only appears when user-journey.yaml is present. When it is
-// missing, both "Analyse Journey" and "Analyse Codebase" are offered so the
-// user can fall back to the full analysis if schema detection failed.
+// When user-journey.yaml is present we expose the three primary actions
+// (view, re-run, deploy) directly so first-time users can reach
+// "Deploy to Skene Cloud" without opening the next-steps modal. When the
+// journey is missing we fall back to the two analysis options.
 func (v *ProjectDirView) buildExistingButtons(projectDir string) *components.ButtonGroup {
 	primary := filepath.Join(projectDir, constants.OutputDirName, constants.UserJourneyFile)
 	if _, err := os.Stat(primary); err == nil {
-		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirRerunAnalysis)
+		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirRerunAnalysis, constants.ProjectDirDeployToCloud)
 	}
 	legacy := filepath.Join(projectDir, constants.LegacyOutputDirName, constants.UserJourneyFile)
 	if _, err := os.Stat(legacy); err == nil {
-		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirRerunAnalysis)
+		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirRerunAnalysis, constants.ProjectDirDeployToCloud)
 	}
 	return components.NewButtonGroup(constants.ProjectDirRunAnalysis, constants.ProjectDirRunCodebaseAnalysis)
 }

--- a/tui/internal/tui/views/project_dir.go
+++ b/tui/internal/tui/views/project_dir.go
@@ -326,11 +326,11 @@ func existingBundleDir(projectDir string) string {
 func (v *ProjectDirView) buildExistingButtons(projectDir string) *components.ButtonGroup {
 	primary := filepath.Join(projectDir, constants.OutputDirName, constants.UserJourneyFile)
 	if _, err := os.Stat(primary); err == nil {
-		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirRerunAnalysis, constants.ProjectDirDeployToCloud)
+		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirDeployToCloud, constants.ProjectDirRerunAnalysis)
 	}
 	legacy := filepath.Join(projectDir, constants.LegacyOutputDirName, constants.UserJourneyFile)
 	if _, err := os.Stat(legacy); err == nil {
-		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirRerunAnalysis, constants.ProjectDirDeployToCloud)
+		return components.NewButtonGroup(constants.ProjectDirViewAnalysis, constants.ProjectDirDeployToCloud, constants.ProjectDirRerunAnalysis)
 	}
 	return components.NewButtonGroup(constants.ProjectDirRunAnalysis, constants.ProjectDirRunCodebaseAnalysis)
 }


### PR DESCRIPTION
## Summary

Promote "Deploy to Skene Cloud" from the next-steps modal to a primary button, so users can reach it without discovering the `n` shortcut.

When `user-journey.yaml` is present, the button row is now: **View Journey | Deploy to Skene Cloud | Re-run Analysis**.

The no-journey fallback (Analyse Journey | Analyse Codebase) is unchanged.

Deploy remains in the next-steps modal as well.

## Test Plan

- [x] Open the TUI on a project with an existing `skene-context` bundle — three buttons render in the order View | Deploy | Re-run.
- [x] Open the TUI on a project without a journey — fallback row still shows Analyse Journey | Analyse Codebase (no Deploy).
- [x] Trigger Deploy from the new button: with no upstream token, it routes through magic-link auth and auto-runs `push` on success; with a token already stored, it runs `push` immediately.
- [x] Trigger Deploy from the `n` modal — still works.

## Checklist

- [x] PR is focused on a single change (no unrelated refactoring or cleanup)
- [ ] ~~Tests added or updated for any behavioral change~~ (n/a - there are no tests at the moment, so this is matching existing conventions)
- [ ] ~~Documentation updated (if behavior, flags, config, or APIs changed)~~ (n/a - no user-facing doc that describes this behaviour)
- [ ] ~~Cursor plugin updated (if commands, skills, or core CLI behavior changed)~~ (n/a)
- [x] Linting and tests pass locally
- [x] No merge conflicts
