### PR TITLE
Inject telemetry credentials at build time

### DIFF
--- a/.github/workflows/tui-release.yml
+++ b/.github/workflows/tui-release.yml
@@ -42,13 +42,20 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
+          TELEMETRY_PROXY_URL: ${{ secrets.TELEMETRY_PROXY_URL }}
+          TELEMETRY_PROXY_KEY: ${{ secrets.TELEMETRY_PROXY_KEY }}
         run: |
           BINARY=skene-${{ matrix.goos }}-${{ matrix.goarch }}
           if [ "${{ matrix.goos }}" = "windows" ]; then
             BINARY="${BINARY}.exe"
           fi
           VERSION="${GITHUB_REF_NAME#tui-}"
-          go build -ldflags "-s -w -X skene/internal/constants.Version=${VERSION}" -o "../build/${BINARY}" ./cmd/skene/
+          go build \
+            -ldflags "-s -w \
+              -X skene/internal/constants.Version=${VERSION} \
+              -X skene/internal/constants.TelemetryProxyURL=${TELEMETRY_PROXY_URL} \
+              -X skene/internal/constants.TelemetryProxyAnonKey=${TELEMETRY_PROXY_KEY}" \
+            -o "../build/${BINARY}" ./cmd/skene/
 
       - name: Package archive
         run: |

--- a/tui/Makefile
+++ b/tui/Makefile
@@ -8,8 +8,17 @@ BUILD_DIR=build
 REPO=SkeneTechnologies/skene
 VERSION=tui-v0.4.0
 
-# Build flags — VERSION is injected into the binary at compile time
-LDFLAGS=-ldflags "-s -w -X skene/internal/constants.Version=$(subst tui-,,$(VERSION))"
+# Telemetry endpoint — injected at release time so forks don't ship with
+# Skene's Supabase credentials. Read from env (set by CI from GitHub
+# secrets); empty in local builds, which disables telemetry at runtime.
+TELEMETRY_PROXY_URL ?=
+TELEMETRY_PROXY_KEY ?=
+
+# Build flags — VERSION + telemetry credentials are injected at compile time
+LDFLAGS=-ldflags "-s -w \
+	-X skene/internal/constants.Version=$(subst tui-,,$(VERSION)) \
+	-X skene/internal/constants.TelemetryProxyURL=$(TELEMETRY_PROXY_URL) \
+	-X skene/internal/constants.TelemetryProxyAnonKey=$(TELEMETRY_PROXY_KEY)"
 HAS_GO := $(shell which go >/dev/null 2>&1 && echo yes || echo no)
 
 # Default target

--- a/tui/internal/constants/constants.go
+++ b/tui/internal/constants/constants.go
@@ -94,12 +94,21 @@ var DashboardFiles = []DashboardFile{
 	{ID: "plan", DisplayName: "Growth Plan", Filename: GrowthPlanFile, Description: FileDescPlan, InContext: true},
 }
 
-// Telemetry — events are sent to a Supabase Edge Function
+// Telemetry — events are sent to a Supabase Edge Function.
+//
+// TelemetryProxyURL and TelemetryProxyAnonKey are injected at release build
+// time via `-ldflags -X` from GitHub secrets (see tui/Makefile and
+// .github/workflows/tui-release.yml). Forks and local source builds get
+// empty defaults, which causes the telemetry client to silently drop all
+// events.
+var (
+	TelemetryProxyURL     = ""
+	TelemetryProxyAnonKey = ""
+)
+
 const (
-	TelemetryProxyURL     = "https://pchtyfolbzguqyxyoyqh.supabase.co/functions/v1/track-event" // TODO: replace with deployed Edge Function URL
-	TelemetryProxyAnonKey = "sb_publishable_PqOH2fvijgns7gyCDFBNAg_2nmZ3saJ"
-	TelemetryQueueSize    = 64
-	TelemetryHTTPTimeout  = 5 * time.Second
+	TelemetryQueueSize   = 64
+	TelemetryHTTPTimeout = 5 * time.Second
 )
 
 // GetTelemetryProxyURL returns the proxy endpoint, honouring the


### PR DESCRIPTION
## Summary

  Fixes the issue where forks shipped Skene's Supabase telemetry credentials and reported events to our project indistinguishably from upstream builds.

  - `TelemetryProxyURL` and `TelemetryProxyAnonKey` in `constants.go` are now `var` defaulting to empty strings
  - The Makefile and `tui-release.yml` inject the real values via `-ldflags -X` from `TELEMETRY_PROXY_URL` / `TELEMETRY_PROXY_KEY` env vars (from GitHub secrets)
  - Forks build with empty values, no behavior change for upstream releases, telemetry becomes a no-op for forks

Notes:
 * Before releasing, add repo secrets `TELEMETRY_PROXY_URL` and `TELEMETRY_PROXY_KEY`. 
 * Consider rotating the Supabase publishable key now that the previous value is exposed in git history

## Test plan

  - [x] `make build` with no env vars → empty `-X` values land in binary (fork case)
  - [x] `make build` with env vars set → values verified in binary via `strings build/skene`
  - [x] `go test ./...` passes
  - [ ] After secrets are configured, confirm a real release binary emits telemetry
  - [ ] Confirm a build from a fork (or with empty secrets) does not emit telemetry

## Checklist

- [x] PR is focused on a single change (no unrelated refactoring or cleanup)
- [ ] ~Tests added or updated for any behavioral change~
- [ ] ~Documentation updated (if behavior, flags, config, or APIs changed)~
- [ ] ~Cursor plugin updated (if commands, skills, or core CLI behavior changed)~
- [ ] Linting and tests pass locally
- [x] No merge conflicts
