### PR TITLE
Reload provider config from config file, fix routing back to recofig

### DIFF
--- a/tui/internal/services/config/manager.go
+++ b/tui/internal/services/config/manager.go
@@ -83,6 +83,20 @@ func (m *Manager) CheckConfigs() []ConfigStatus {
 	return statuses
 }
 
+// ReloadConfig discards any in-memory edits and reloads the configuration
+// from disk. Used when re-entering screens that must reflect the saved
+// state (e.g. the "Existing Configuration Found" check after the user
+// abandoned a Reconfigure flow with Esc).
+func (m *Manager) ReloadConfig() error {
+	m.Config = &Config{
+		OutputDir:        constants.DefaultOutputDir,
+		Verbose:          true,
+		UseGrowth:        true,
+		TelemetryEnabled: true,
+	}
+	return m.LoadConfig()
+}
+
 // LoadConfig loads configuration from files.
 // User config is loaded first, then project config is merged on top
 // (project values take precedence), matching the Python CLI behaviour.

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -599,6 +599,20 @@ func (a *App) handleKeyPress(msg tea.KeyMsg) tea.Cmd {
 func (a *App) handleWelcomeKeys(key string) tea.Cmd {
 	switch key {
 	case "enter":
+		// Always reload from disk so the ConfigCheck screen reflects the
+		// saved configuration, not whatever the user touched in memory
+		// during an abandoned Reconfigure flow. Also discard any
+		// half-built views from that flow so later back-navigation
+		// (e.g. from StateProjectDir) doesn't land on a stale API key
+		// or model screen that belongs to a provider the user backed
+		// out of.
+		_ = a.configMgr.ReloadConfig()
+		a.selectedProvider = nil
+		a.selectedModel = nil
+		a.apiKeyView = nil
+		a.modelView = nil
+		a.localModelView = nil
+		a.authView = nil
 		if a.configMgr.HasValidConfig() {
 			a.populateSelectedFromConfig()
 			providerName := a.configMgr.Config.Provider


### PR DESCRIPTION
## Summary
Existing user config would get overwritten by in memory configuration while going partly through configuration and then returning back to existing configuration view. The provider was shown from the memory not from the actual .config file. 

Additionally a rerouting issue was found when provider would be selected, api key view entered, the user would navigation back and select existing configuration, enter the project_dir view and then navigate back. They would see the API auth view that they previously visited.

## Fix

Fixed rerouting and forcing to reload from config on the existing config view.

## Checklist

- [X] PR is focused on a single change (no unrelated refactoring or cleanup)
- [X] Tests added or updated for any behavioral change
- [ ] Documentation updated (if behavior, flags, config, or APIs changed)
- [ ] Cursor plugin updated (if commands, skills, or core CLI behavior changed)
- [X] Linting and tests pass locally
- [X] No merge conflicts
