### PR TITLE
Auto-publish journey.yaml to Skene Cloud on first analysis

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -82,6 +82,8 @@ uvx skene build
 uvx skene push
 ```
 
+> **Note:** If you run **journey analysis from the TUI** while linked to a workspace, your `journey.yaml` is published to Skene Cloud automatically on first run — no manual `push` needed for the journey to appear in the cloud canvas. The `build → push` flow above is still how you deploy engine artifacts and Supabase triggers. See [Automatic first publish](../guides/push.md#automatic-first-publish-journey-analysis).
+
 ## What you get
 
 Your `./skene-context/` directory contains:

--- a/docs/guides/push.md
+++ b/docs/guides/push.md
@@ -59,6 +59,14 @@ uvx skene push --upstream https://skene.ai/workspace/my-app
 
 Trigger SQL is produced by `build` for engine features that define `action`.
 
+## Automatic first publish (journey analysis)
+
+You don't always need an explicit `push` for a **journey** to reach Skene Cloud. When you run journey analysis from the **TUI** while linked to a workspace (the `skene` provider), Skene publishes the generated `journey.yaml` automatically — but only when the workspace has **no journey upstream yet**. This is so a first-time user's journey appears in the cloud Customer Journey canvas without a manual step.
+
+- If a journey already exists upstream, nothing is published (your existing journey is never overwritten).
+- If the presence check can't be completed, publishing is skipped silently.
+- A normal `skene push` still uploads the full bundle (engine, registry, migrations, journey) as described above.
+
 ## Upstream authentication
 
 ```bash

--- a/src/skene/cli/commands/analyse_journey.py
+++ b/src/skene/cli/commands/analyse_journey.py
@@ -275,10 +275,7 @@ def _maybe_auto_publish(rc, project_root: Path, *, enabled: bool) -> None:
     if result.get("ok"):
         success("✓ Published journey to Skene Cloud.")
     else:
-        warning(
-            "Could not publish journey to Skene Cloud: "
-            f"{result.get('message', 'unknown error')}"
-        )
+        warning(f"Could not publish journey to Skene Cloud: {result.get('message', 'unknown error')}")
 
 
 def _infer_product_name(repo_root: Path | None, schema_dir: Path | None) -> str:

--- a/src/skene/cli/commands/analyse_journey.py
+++ b/src/skene/cli/commands/analyse_journey.py
@@ -126,6 +126,16 @@ def analyse_journey_cmd(
         "--no-fallback",
         help="Disable model fallback on rate limits; retry same model instead",
     ),
+    auto_publish: bool = typer.Option(
+        False,
+        "--auto-publish",
+        hidden=True,
+        help=(
+            "After writing journey.yaml, publish it to Skene Cloud when linked to a "
+            "skene workspace and no journey.yaml exists upstream yet. Set by the TUI; "
+            "a no-op for any other provider or when a remote journey already exists."
+        ),
+    ),
 ) -> None:
     """
     Generate a journey.yaml describing the user lifecycle of the target product.
@@ -216,6 +226,59 @@ def analyse_journey_cmd(
     write_journey(journey, journey_path)
 
     _render_summary(journey_path, journey)
+
+    _maybe_auto_publish(rc, config_root, enabled=auto_publish)
+
+
+def _maybe_auto_publish(rc, project_root: Path, *, enabled: bool) -> None:
+    """Publish the freshly written journey.yaml to Skene Cloud on first run.
+
+    Gated on (in order): the TUI-only ``--auto-publish`` opt-in, the skene
+    provider with a linked workspace (upstream URL + token), and the absence of
+    a journey.yaml upstream. A failed or indeterminate presence check skips
+    publishing silently — we never push unless skene.ai definitively reports no
+    journey. Never raises: a publish failure must not fail journey analysis.
+    """
+    if not enabled:
+        return
+
+    from skene.config import resolve_upstream_token
+    from skene.growth_loops.push import publish_bundle
+    from skene.growth_loops.upstream import (
+        _api_base_from_upstream,
+        journey_exists_upstream,
+    )
+    from skene.output import success, warning
+
+    config = rc.config
+    if config.provider != "skene":
+        return
+
+    upstream = config.upstream
+    token = resolve_upstream_token(config)
+    if not upstream or not token:
+        return
+
+    api_base = _api_base_from_upstream(upstream)
+
+    present = journey_exists_upstream(api_base, token)
+    if present is not False:
+        # True (already published) or None (indeterminate) → leave it alone.
+        return
+
+    try:
+        result = publish_bundle(project_root, config, upstream=upstream, token=token)
+    except Exception as exc:  # noqa: BLE001 — auto-publish is best-effort
+        warning(f"Could not publish journey to Skene Cloud: {exc}")
+        return
+
+    if result.get("ok"):
+        success("✓ Published journey to Skene Cloud.")
+    else:
+        warning(
+            "Could not publish journey to Skene Cloud: "
+            f"{result.get('message', 'unknown error')}"
+        )
 
 
 def _infer_product_name(repo_root: Path | None, schema_dir: Path | None) -> str:

--- a/src/skene/cli/commands/push.py
+++ b/src/skene/cli/commands/push.py
@@ -6,10 +6,8 @@ import typer
 
 from skene.cli.app import app, resolve_cli_config
 from skene.config import resolve_upstream_token
-from skene.engine import collect_engine_trigger_events, default_engine_path, load_engine_document
-from skene.growth_loops.push import push_to_upstream
+from skene.growth_loops.push import publish_bundle
 from skene.output import error, success, warning
-from skene.output_paths import DEFAULT_OUTPUT_DIR
 
 
 @app.command()
@@ -58,31 +56,13 @@ def push(
         error("No token. Run skene login to authenticate.")
         raise typer.Exit(1)
 
-    out_dir = rc.config.output_dir or DEFAULT_OUTPUT_DIR
-    engine_path = default_engine_path(project_root, out_dir)
-
-    trigger_events: list[str] = []
-    features_count = 0
-    if engine_path.exists():
-        try:
-            engine_doc = load_engine_document(engine_path, project_root=project_root)
-            trigger_events = collect_engine_trigger_events(engine_doc)
-            features_count = len(engine_doc.features)
-        except Exception as exc:
-            warning(
-                f"Could not extract manifest metadata from the engine ({exc}). "
-                "Continuing with empty trigger_events and zero features_count."
-            )
-
     try:
-        result = push_to_upstream(
-            project_root=project_root,
-            upstream_url=resolved_upstream,
+        result = publish_bundle(
+            project_root,
+            rc.config,
+            upstream=resolved_upstream,
             token=resolved_token,
-            trigger_events=trigger_events,
-            features_count=features_count,
-            output_dir=out_dir,
-            engine_path=engine_path,
+            warn=warning,
         )
     except Exception as exc:
         error(f"Deploy failed: {exc}")

--- a/src/skene/growth_loops/push.py
+++ b/src/skene/growth_loops/push.py
@@ -7,11 +7,15 @@ Builds migration files that create:
 """
 
 import re
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from skene.growth_loops.schema_sql import BASE_SCHEMA_SQL, notify_event_log_sql
+
+if TYPE_CHECKING:
+    from skene.config import Config
 
 BASE_SCHEMA_MIGRATION_PREFIX = "20260201000000"
 BASE_SCHEMA_MIGRATION_NAME = "skene_growth_schema"
@@ -284,6 +288,66 @@ def push_to_upstream(
         loops_count=features_count,
         engine_path=engine_path,
         output_dir=output_dir,
+    )
+
+
+def publish_bundle(
+    project_root: Path,
+    config: "Config",
+    *,
+    upstream: str | None = None,
+    token: str | None = None,
+    warn: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Collect bundle artifacts + engine metadata and push them upstream.
+
+    Resolves the upstream URL, token, and output dir from ``config`` when not
+    passed explicitly, extracts trigger events / feature count from the engine
+    document (if present), and delegates to :func:`push_to_upstream`. Returns
+    the push result dict (``{"ok": bool, ...}``).
+
+    Raises ``ValueError`` when no upstream token is available. When engine
+    metadata cannot be read, ``warn`` (if given) is called and the push
+    continues with empty trigger events / zero features.
+    """
+    from skene.config import resolve_upstream_token
+    from skene.engine import (
+        collect_engine_trigger_events,
+        default_engine_path,
+        load_engine_document,
+    )
+    from skene.output_paths import DEFAULT_OUTPUT_DIR
+
+    resolved_upstream = upstream or config.upstream or ""
+    resolved_token = token or resolve_upstream_token(config)
+    if not resolved_token:
+        raise ValueError("No upstream token. Run skene login to authenticate.")
+
+    out_dir = config.output_dir or DEFAULT_OUTPUT_DIR
+    engine_path = default_engine_path(project_root, out_dir)
+
+    trigger_events: list[str] = []
+    features_count = 0
+    if engine_path.exists():
+        try:
+            engine_doc = load_engine_document(engine_path, project_root=project_root)
+            trigger_events = collect_engine_trigger_events(engine_doc)
+            features_count = len(engine_doc.features)
+        except Exception as exc:  # noqa: BLE001 — metadata is best-effort
+            if warn is not None:
+                warn(
+                    f"Could not extract manifest metadata from the engine ({exc}). "
+                    "Continuing with empty trigger_events and zero features_count."
+                )
+
+    return push_to_upstream(
+        project_root=project_root,
+        upstream_url=resolved_upstream,
+        token=resolved_token,
+        trigger_events=trigger_events,
+        features_count=features_count,
+        output_dir=out_dir,
+        engine_path=engine_path,
     )
 
 

--- a/src/skene/growth_loops/upstream.py
+++ b/src/skene/growth_loops/upstream.py
@@ -87,6 +87,30 @@ def validate_token(api_base: str, token: str) -> bool:
         return False
 
 
+def journey_exists_upstream(api_base: str, token: str) -> bool | None:
+    """Report whether the workspace already has a pushed ``journey.yaml`` upstream.
+
+    Calls ``GET /journey/status`` (token-scoped; the workspace is resolved from
+    the token). Returns ``True``/``False`` on a definitive answer, or ``None``
+    when the result is indeterminate (non-200, network error, or an endpoint
+    that is not deployed yet) so callers can safely skip auto-publishing.
+    """
+    url = f"{api_base.rstrip('/')}/journey/status"
+    try:
+        resp = httpx.get(
+            url,
+            headers=_auth_headers(token),
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if isinstance(data, dict):
+                return bool(data.get("data", {}).get("exists"))
+        return None
+    except Exception:
+        return None
+
+
 def _relative_path(path: Path, project_root: Path) -> str:
     """Return ``path`` as a POSIX-style string relative to ``project_root``."""
     try:

--- a/tests/test_cli/test_analyse_journey_auto_publish.py
+++ b/tests/test_cli/test_analyse_journey_auto_publish.py
@@ -39,9 +39,7 @@ def patched(monkeypatch):
         calls["publish"].append((project_root, config, kwargs))
         return calls.get("publish_result", {"ok": True})
 
-    monkeypatch.setattr(
-        "skene.growth_loops.upstream.journey_exists_upstream", fake_exists
-    )
+    monkeypatch.setattr("skene.growth_loops.upstream.journey_exists_upstream", fake_exists)
     monkeypatch.setattr("skene.growth_loops.push.publish_bundle", fake_publish)
     return calls
 

--- a/tests/test_cli/test_analyse_journey_auto_publish.py
+++ b/tests/test_cli/test_analyse_journey_auto_publish.py
@@ -1,0 +1,110 @@
+"""Gating tests for analyse-journey's first-run auto-publish.
+
+`_maybe_auto_publish` must only push to Skene Cloud when: the TUI passed
+``--auto-publish``, the run is on the skene provider with a linked workspace
+(upstream URL + token), and skene.ai definitively reports no journey.yaml yet.
+A True/None presence result (already published / indeterminate) must skip the
+push, and a push failure must never raise.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from skene.cli.commands.analyse_journey import _maybe_auto_publish
+from skene.config import Config
+
+
+def _rc(provider="skene", upstream="https://skene.ai/workspace/w", token="sk_token"):
+    cfg = Config()
+    cfg.set("provider", provider)
+    if upstream:
+        cfg.set("upstream", upstream)
+    if token:
+        cfg.set("upstream_api_key", token)
+    return SimpleNamespace(config=cfg)
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch the lazily-imported collaborators and capture calls."""
+    calls = {"exists": [], "publish": []}
+
+    def fake_exists(api_base, tok):
+        calls["exists"].append((api_base, tok))
+        return calls["exists_result"]
+
+    def fake_publish(project_root, config, **kwargs):
+        calls["publish"].append((project_root, config, kwargs))
+        return calls.get("publish_result", {"ok": True})
+
+    monkeypatch.setattr(
+        "skene.growth_loops.upstream.journey_exists_upstream", fake_exists
+    )
+    monkeypatch.setattr("skene.growth_loops.push.publish_bundle", fake_publish)
+    return calls
+
+
+def test_disabled_does_nothing(patched, tmp_path):
+    patched["exists_result"] = False
+    _maybe_auto_publish(_rc(), tmp_path, enabled=False)
+    assert patched["exists"] == []
+    assert patched["publish"] == []
+
+
+def test_non_skene_provider_skips(patched, tmp_path):
+    patched["exists_result"] = False
+    _maybe_auto_publish(_rc(provider="openai"), tmp_path, enabled=True)
+    assert patched["exists"] == []
+    assert patched["publish"] == []
+
+
+def test_missing_upstream_skips(patched, tmp_path):
+    patched["exists_result"] = False
+    _maybe_auto_publish(_rc(upstream=""), tmp_path, enabled=True)
+    assert patched["exists"] == []
+    assert patched["publish"] == []
+
+
+def test_missing_token_skips(patched, tmp_path, monkeypatch):
+    # Force token resolution to fail regardless of the host's env/credentials.
+    monkeypatch.setattr("skene.config.resolve_upstream_token", lambda cfg: None)
+    patched["exists_result"] = False
+    _maybe_auto_publish(_rc(token=""), tmp_path, enabled=True)
+    assert patched["exists"] == []
+    assert patched["publish"] == []
+
+
+def test_already_published_skips(patched, tmp_path):
+    patched["exists_result"] = True
+    _maybe_auto_publish(_rc(), tmp_path, enabled=True)
+    assert len(patched["exists"]) == 1
+    assert patched["publish"] == []
+
+
+def test_indeterminate_skips(patched, tmp_path):
+    patched["exists_result"] = None
+    _maybe_auto_publish(_rc(), tmp_path, enabled=True)
+    assert len(patched["exists"]) == 1
+    assert patched["publish"] == []
+
+
+def test_absent_publishes(patched, tmp_path):
+    patched["exists_result"] = False
+    _maybe_auto_publish(_rc(), tmp_path, enabled=True)
+    assert len(patched["publish"]) == 1
+    project_root, config, kwargs = patched["publish"][0]
+    assert project_root == tmp_path
+    assert kwargs["upstream"] == "https://skene.ai/workspace/w"
+    assert kwargs["token"] == "sk_token"
+
+
+def test_publish_failure_does_not_raise(patched, tmp_path):
+    patched["exists_result"] = False
+
+    def boom(*a, **k):
+        raise RuntimeError("network down")
+
+    with patch("skene.growth_loops.push.publish_bundle", boom):
+        _maybe_auto_publish(_rc(), tmp_path, enabled=True)  # must not raise

--- a/tests/test_growth_loops/test_upstream.py
+++ b/tests/test_growth_loops/test_upstream.py
@@ -9,6 +9,7 @@ from skene.growth_loops.upstream import (
     _workspace_slug_from_url,
     build_push_manifest,
     collect_push_files,
+    journey_exists_upstream,
     push_to_upstream,
     validate_token,
 )
@@ -133,6 +134,38 @@ class TestValidateToken:
     def test_invalid_token(self, mock_get):
         mock_get.return_value.status_code = 401
         assert validate_token("https://x.com/api/v1", "bad") is False
+
+
+class TestJourneyExistsUpstream:
+    @patch("skene.growth_loops.upstream.httpx.get")
+    def test_exists_true(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": {"exists": True}}
+        assert journey_exists_upstream("https://x.com/api/v1", "sk_xxx") is True
+        # Hits the /journey/status endpoint.
+        assert mock_get.call_args.args[0].endswith("/journey/status")
+
+    @patch("skene.growth_loops.upstream.httpx.get")
+    def test_exists_false(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": {"exists": False}}
+        assert journey_exists_upstream("https://x.com/api/v1", "sk_xxx") is False
+
+    @patch("skene.growth_loops.upstream.httpx.get")
+    def test_non_200_is_indeterminate(self, mock_get):
+        mock_get.return_value.status_code = 404
+        assert journey_exists_upstream("https://x.com/api/v1", "sk_xxx") is None
+
+    @patch("skene.growth_loops.upstream.httpx.get")
+    def test_exception_is_indeterminate(self, mock_get):
+        mock_get.side_effect = RuntimeError("boom")
+        assert journey_exists_upstream("https://x.com/api/v1", "sk_xxx") is None
+
+    @patch("skene.growth_loops.upstream.httpx.get")
+    def test_missing_exists_field_is_falsey(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"data": {}}
+        assert journey_exists_upstream("https://x.com/api/v1", "sk_xxx") is False
 
 
 class TestPushToUpstream:

--- a/tui/internal/services/growth/engine.go
+++ b/tui/internal/services/growth/engine.go
@@ -142,22 +142,27 @@ func (e *Engine) RunJourney(ctx context.Context) *AnalysisResult {
 
 	e.sendUpdate(PhaseScanCodebase, 0.0, "Starting journey analysis...")
 
-	bundle := e.bundleOutputDir()
-	args := []string{
-		constants.GrowthPackageSpec(), "analyse-journey", ".",
-		"-o", filepath.Join(bundle, constants.JourneyFile),
-	}
-
-	if err := e.runUVX(ctx, args); err != nil {
+	if err := e.runUVX(ctx, e.journeyArgs()); err != nil {
 		result.Error = fmt.Errorf("analyse-journey failed: %w", err)
 		return result
 	}
 
 	e.sendUpdate(PhaseGenerateDocs, 1.0, "Analysis complete")
 
-	result.Journey = loadFileContent(filepath.Join(bundle, constants.JourneyFile))
+	result.Journey = loadFileContent(filepath.Join(e.bundleOutputDir(), constants.JourneyFile))
 
 	return result
+}
+
+func (e *Engine) journeyArgs() []string {
+	args := []string{
+		constants.GrowthPackageSpec(), "analyse-journey", ".",
+		"-o", filepath.Join(e.bundleOutputDir(), constants.JourneyFile),
+	}
+	if e.config.Provider == "skene" && e.config.Upstream != "" && e.config.UpstreamAPIKey != "" {
+		args = append(args, "--auto-publish")
+	}
+	return args
 }
 
 // GeneratePlan spawns uvx skene plan

--- a/tui/internal/services/growth/engine_test.go
+++ b/tui/internal/services/growth/engine_test.go
@@ -54,6 +54,46 @@ func TestBuildEnvVarsIncludesSkeneOutputDir(t *testing.T) {
 	}
 }
 
+func hasArg(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
+func TestJourneyArgsAppendsAutoPublishWhenLinked(t *testing.T) {
+	e := &Engine{config: EngineConfig{
+		ProjectDir:     "/tmp/project",
+		Provider:       "skene",
+		Upstream:       "https://www.skene.ai/workspace/my-app",
+		UpstreamAPIKey: "sk_token",
+	}}
+	if !hasArg(e.journeyArgs(), "--auto-publish") {
+		t.Fatalf("expected --auto-publish for a linked skene run; got %v", e.journeyArgs())
+	}
+}
+
+func TestJourneyArgsOmitsAutoPublishCases(t *testing.T) {
+	cases := []struct {
+		name   string
+		config EngineConfig
+	}{
+		{"non-skene provider", EngineConfig{ProjectDir: "/p", Provider: "openai", Upstream: "https://www.skene.ai/workspace/a", UpstreamAPIKey: "k"}},
+		{"skene without upstream", EngineConfig{ProjectDir: "/p", Provider: "skene", UpstreamAPIKey: "k"}},
+		{"skene without key", EngineConfig{ProjectDir: "/p", Provider: "skene", Upstream: "https://www.skene.ai/workspace/a"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Engine{config: tc.config}
+			if hasArg(e.journeyArgs(), "--auto-publish") {
+				t.Fatalf("did not expect --auto-publish; got %v", e.journeyArgs())
+			}
+		})
+	}
+}
+
 func TestDefaultOutputDirConstant(t *testing.T) {
 	if constants.DefaultOutputDir != "./skene-context" {
 		t.Fatalf("DefaultOutputDir regressed; got %q", constants.DefaultOutputDir)

--- a/uv.lock
+++ b/uv.lock
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "skene"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

First-time Skene TUI users who link a workspace and run journey analysis land on an **empty** Customer Journey canvas after following the visualization's link to skene.ai (they haven't pushed `journey.yaml` yet). This change auto-publishes the generated `journey.yaml` right after analysis, so the cloud canvas is populated by the time they click through.

It only fires when **both** hold:
1. running with the skene provider (TUI linked to a workspace), and
2. no `journey.yaml` exists upstream yet.

The gate is split between the TUI (knows it's linked) and the CLI (does the check + push):

- **TUI** (`tui/internal/services/growth/engine.go`): extracted `analyse-journey` arg building into `journeyArgs()`, which appends `--auto-publish` only when linked (skene provider + upstream URL + key). The flag's presence marks a TUI-initiated, linked run.
- **CLI** (`src/skene/cli/commands/analyse_journey.py`): hidden `--auto-publish` flag + `_maybe_auto_publish`, gated on skene provider + linked workspace + definitive remote absence. Already-present or indeterminate results skip silently; a publish failure never fails analysis.
- **Presence check** (`src/skene/growth_loops/upstream.py`): `journey_exists_upstream()` calls `GET /api/v1/journey/status`; returns `None` on any indeterminate result (non-200, network error, endpoint not deployed) so callers can skip safely.
- **Refactor** (`src/skene/growth_loops/push.py`): extracted `publish_bundle()` so the existing `push` command and the new auto-publish path build an identical manifest (no behavior change to `skene push`).

### Design decisions

- **Indeterminate check -> skip silently.** Only a definitive "absent" triggers a push; we never push when the check can't be completed.
- **TUI-initiated only.** Direct `skene analyse-journey` CLI runs never auto-publish, even when linked — it's gated on the flag the TUI sets.

### Dependency

Needs the dashboard endpoint `GET /api/v1/journey/status` (SkeneTechnologies/skene-dashboard#200). Until that's deployed the presence check is indeterminate and auto-publish is a no-op, so this can merge/ship independently.

## Test Plan

**Automated** (run locally):

  - [x] uv run pytest (395 passed, incl. the new test_upstream.py + test_analyse_journey_auto_publish.py)
  - [x] uv run ruff check clean.
  - [x] cd tui && go test ./internal/services/growth/

What the unit tests cover:

  - journey_exists_upstream — 200 exists true/false; non-200 and exceptions → None (indeterminate).
  - _maybe_auto_publish — full gating matrix: disabled, non-skene provider, missing upstream/token, already-present,
  indeterminate, absent→publish; plus publish-failure-never-raises.
  - journeyArgs — appends --auto-publish only when provider=skene + upstream + key; omitted otherwise.

**Manual end-to-end**

  - [ ] Deploy GET /api/v1/journey/status; curl -H "X-API-Key: <key>" …/api/v1/journey/status → { "data": { "exists": false } } on a fresh workspace.
  - [ ] Link the TUI (skene provider) and run journey analysis → expect a "Published journey to Skene Cloud" line; re-check returns exists: true and the skene.ai canvas renders.
  - [ ] Re-run on the same workspace → check returns true → no re-push.
  - [ ] Non-skene provider → no --auto-publish, no upstream call.
  - [ ] Endpoint unreachable → publish skipped silently, analysis still succeeds.



## Checklist

  - [x] PR is focused on a single change (no unrelated refactoring or cleanup)
  - [x] Tests added or updated for any behavioral change
  - [x] Documentation updated (if behavior, flags, config, or APIs changed)
  - [ ] ~Cursor plugin updated (if commands, skills, or core CLI behavior changed)~ n/a
  - [x] Linting and tests pass locally
  - [x] No merge conflicts

