### PR TITLE
Anchor journey auto-publish to the freshly written journey directory

### DIFF
--- a/src/skene/cli/commands/analyse_journey.py
+++ b/src/skene/cli/commands/analyse_journey.py
@@ -227,10 +227,10 @@ def analyse_journey_cmd(
 
     _render_summary(journey_path, journey)
 
-    _maybe_auto_publish(rc, config_root, enabled=auto_publish)
+    _maybe_auto_publish(rc, config_root, journey_path=journey_path, enabled=auto_publish)
 
 
-def _maybe_auto_publish(rc, project_root: Path, *, enabled: bool) -> None:
+def _maybe_auto_publish(rc, project_root: Path, *, journey_path: Path, enabled: bool) -> None:
     """Publish the freshly written journey.yaml to Skene Cloud on first run.
 
     Gated on (in order): the TUI-only ``--auto-publish`` opt-in, the skene
@@ -238,8 +238,15 @@ def _maybe_auto_publish(rc, project_root: Path, *, enabled: bool) -> None:
     a journey.yaml upstream. A failed or indeterminate presence check skips
     publishing silently — we never push unless skene.ai definitively reports no
     journey. Never raises: a publish failure must not fail journey analysis.
+
+    The push is anchored to ``journey_path``'s directory (where we just wrote the
+    journey), not ``config.output_dir`` — the latter can resolve to a stale legacy
+    ``skene/`` bundle and silently exclude the freshly written ``journey.yaml``.
     """
+    from skene.output import debug, success, warning
+
     if not enabled:
+        debug("auto-publish: skipped (flag not set; not a linked TUI run)")
         return
 
     from skene.config import resolve_upstream_token
@@ -248,26 +255,43 @@ def _maybe_auto_publish(rc, project_root: Path, *, enabled: bool) -> None:
         _api_base_from_upstream,
         journey_exists_upstream,
     )
-    from skene.output import success, warning
 
     config = rc.config
     if config.provider != "skene":
+        debug(f"auto-publish: skipped (provider is {config.provider!r}, not 'skene')")
         return
 
     upstream = config.upstream
     token = resolve_upstream_token(config)
     if not upstream or not token:
+        debug(
+            "auto-publish: skipped (not linked: "
+            f"upstream={'set' if upstream else 'missing'}, "
+            f"token={'set' if token else 'missing'})"
+        )
         return
 
     api_base = _api_base_from_upstream(upstream)
 
+    # The workspace is resolved server-side from the token (1:1), so a "present"
+    # result means *this token's* workspace already has a journey.yaml.
     present = journey_exists_upstream(api_base, token)
     if present is not False:
         # True (already published) or None (indeterminate) → leave it alone.
+        reason = "already present upstream" if present else "presence check indeterminate"
+        debug(f"auto-publish: skipped ({reason})")
         return
 
+    debug("auto-publish: publishing journey (workspace empty upstream)")
+
     try:
-        result = publish_bundle(project_root, config, upstream=upstream, token=token)
+        result = publish_bundle(
+            project_root,
+            config,
+            upstream=upstream,
+            token=token,
+            output_dir=str(journey_path.parent),
+        )
     except Exception as exc:  # noqa: BLE001 — auto-publish is best-effort
         warning(f"Could not publish journey to Skene Cloud: {exc}")
         return

--- a/src/skene/growth_loops/push.py
+++ b/src/skene/growth_loops/push.py
@@ -297,6 +297,7 @@ def publish_bundle(
     *,
     upstream: str | None = None,
     token: str | None = None,
+    output_dir: str | None = None,
     warn: Callable[[str], None] | None = None,
 ) -> dict[str, Any]:
     """Collect bundle artifacts + engine metadata and push them upstream.
@@ -305,6 +306,10 @@ def publish_bundle(
     passed explicitly, extracts trigger events / feature count from the engine
     document (if present), and delegates to :func:`push_to_upstream`. Returns
     the push result dict (``{"ok": bool, ...}``).
+
+    ``output_dir`` overrides ``config.output_dir`` for the uploaded bundle. Pass
+    it to anchor the push to a known directory (e.g. where ``journey.yaml`` was
+    just written) instead of the config's sticky/legacy resolution.
 
     Raises ``ValueError`` when no upstream token is available. When engine
     metadata cannot be read, ``warn`` (if given) is called and the push
@@ -323,7 +328,7 @@ def publish_bundle(
     if not resolved_token:
         raise ValueError("No upstream token. Run skene login to authenticate.")
 
-    out_dir = config.output_dir or DEFAULT_OUTPUT_DIR
+    out_dir = output_dir or config.output_dir or DEFAULT_OUTPUT_DIR
     engine_path = default_engine_path(project_root, out_dir)
 
     trigger_events: list[str] = []

--- a/tests/test_cli/test_analyse_journey_auto_publish.py
+++ b/tests/test_cli/test_analyse_journey_auto_publish.py
@@ -26,6 +26,11 @@ def _rc(provider="skene", upstream="https://skene.ai/workspace/w", token="sk_tok
     return SimpleNamespace(config=cfg)
 
 
+def _jp(tmp_path):
+    """The path analyse-journey would write the journey to."""
+    return tmp_path / "skene-context" / "journey.yaml"
+
+
 @pytest.fixture
 def patched(monkeypatch):
     """Patch the lazily-imported collaborators and capture calls."""
@@ -46,21 +51,21 @@ def patched(monkeypatch):
 
 def test_disabled_does_nothing(patched, tmp_path):
     patched["exists_result"] = False
-    _maybe_auto_publish(_rc(), tmp_path, enabled=False)
+    _maybe_auto_publish(_rc(), tmp_path, journey_path=_jp(tmp_path), enabled=False)
     assert patched["exists"] == []
     assert patched["publish"] == []
 
 
 def test_non_skene_provider_skips(patched, tmp_path):
     patched["exists_result"] = False
-    _maybe_auto_publish(_rc(provider="openai"), tmp_path, enabled=True)
+    _maybe_auto_publish(_rc(provider="openai"), tmp_path, journey_path=_jp(tmp_path), enabled=True)
     assert patched["exists"] == []
     assert patched["publish"] == []
 
 
 def test_missing_upstream_skips(patched, tmp_path):
     patched["exists_result"] = False
-    _maybe_auto_publish(_rc(upstream=""), tmp_path, enabled=True)
+    _maybe_auto_publish(_rc(upstream=""), tmp_path, journey_path=_jp(tmp_path), enabled=True)
     assert patched["exists"] == []
     assert patched["publish"] == []
 
@@ -69,33 +74,36 @@ def test_missing_token_skips(patched, tmp_path, monkeypatch):
     # Force token resolution to fail regardless of the host's env/credentials.
     monkeypatch.setattr("skene.config.resolve_upstream_token", lambda cfg: None)
     patched["exists_result"] = False
-    _maybe_auto_publish(_rc(token=""), tmp_path, enabled=True)
+    _maybe_auto_publish(_rc(token=""), tmp_path, journey_path=_jp(tmp_path), enabled=True)
     assert patched["exists"] == []
     assert patched["publish"] == []
 
 
 def test_already_published_skips(patched, tmp_path):
     patched["exists_result"] = True
-    _maybe_auto_publish(_rc(), tmp_path, enabled=True)
+    _maybe_auto_publish(_rc(), tmp_path, journey_path=_jp(tmp_path), enabled=True)
     assert len(patched["exists"]) == 1
     assert patched["publish"] == []
 
 
 def test_indeterminate_skips(patched, tmp_path):
     patched["exists_result"] = None
-    _maybe_auto_publish(_rc(), tmp_path, enabled=True)
+    _maybe_auto_publish(_rc(), tmp_path, journey_path=_jp(tmp_path), enabled=True)
     assert len(patched["exists"]) == 1
     assert patched["publish"] == []
 
 
 def test_absent_publishes(patched, tmp_path):
     patched["exists_result"] = False
-    _maybe_auto_publish(_rc(), tmp_path, enabled=True)
+    _maybe_auto_publish(_rc(), tmp_path, journey_path=_jp(tmp_path), enabled=True)
     assert len(patched["publish"]) == 1
     project_root, config, kwargs = patched["publish"][0]
     assert project_root == tmp_path
     assert kwargs["upstream"] == "https://skene.ai/workspace/w"
     assert kwargs["token"] == "sk_token"
+    # The push is anchored to the journey's own directory, never config.output_dir
+    # (which can resolve to a stale legacy skene/ bundle).
+    assert kwargs["output_dir"] == str(_jp(tmp_path).parent)
 
 
 def test_publish_failure_does_not_raise(patched, tmp_path):
@@ -105,4 +113,4 @@ def test_publish_failure_does_not_raise(patched, tmp_path):
         raise RuntimeError("network down")
 
     with patch("skene.growth_loops.push.publish_bundle", boom):
-        _maybe_auto_publish(_rc(), tmp_path, enabled=True)  # must not raise
+        _maybe_auto_publish(_rc(), tmp_path, journey_path=_jp(tmp_path), enabled=True)  # must not raise

--- a/tests/test_growth_loops/test_upstream.py
+++ b/tests/test_growth_loops/test_upstream.py
@@ -224,3 +224,42 @@ class TestPushToUpstream:
         result = push_to_upstream(tmp_path, "https://x.com/workspace/w", "bad", [], 0)
         assert result["ok"] is False
         assert result["error"] == "auth"
+
+
+class TestPublishBundleOutputDirOverride:
+    """Regression: auto-publish must push the journey's own directory, never a
+    stale legacy ``skene/`` bundle (the cause of a 201 that omitted journey.yaml)."""
+
+    @patch("skene.growth_loops.upstream.httpx.post")
+    def test_output_dir_override_pushes_journey_not_legacy_skene(self, mock_post, tmp_path: Path):
+        from skene.config import Config
+        from skene.growth_loops.push import publish_bundle
+
+        # Stale legacy bundle (e.g. left over from an old run) ...
+        (tmp_path / "skene").mkdir(parents=True)
+        (tmp_path / "skene" / "growth-template.json").write_text('{"loops": []}\n')
+        # ... and the freshly written journey in the canonical bundle.
+        (tmp_path / "skene-context").mkdir(parents=True)
+        (tmp_path / "skene-context" / "journey.yaml").write_text("journey: {}\n")
+
+        mock_post.return_value.status_code = 201
+        mock_post.return_value.json.return_value = {"commit_hash": "sha256:abc"}
+
+        cfg = Config()
+        cfg.set("provider", "skene")
+        cfg.set("upstream", "https://skene.ai/workspace/w")
+        # config.output_dir resolves to the legacy dir — the buggy condition.
+        cfg.set("output_dir", "./skene")
+
+        result = publish_bundle(
+            tmp_path,
+            cfg,
+            upstream="https://skene.ai/workspace/w",
+            token="sk_token",
+            output_dir=str(tmp_path / "skene-context"),
+        )
+
+        assert result["ok"] is True
+        paths = [f["path"] for f in mock_post.call_args.kwargs["json"]["files"]]
+        assert "skene-context/journey.yaml" in paths
+        assert "skene/growth-template.json" not in paths


### PR DESCRIPTION
## Summary

Follow-up bug fix to journey auto-publish (#85). The auto-publish path
called `publish_bundle(...)` without an explicit directory, so it fell
back to `config.output_dir`. On a machine with a stale legacy `skene/`
bundle, that resolves to the old directory rather than `skene-context/`
where analysis just wrote `journey.yaml` — so the push returned `201 OK`
but **silently omitted the journey**, defeating the feature.

This PR:
- Adds an `output_dir` override to `publish_bundle()` so callers can pin
  the push to a known directory instead of the config's sticky/legacy
  resolution.
- Threads the freshly-written journey's own directory
  (`journey_path.parent`) through `_maybe_auto_publish` into the push.
- Adds `debug()` tracing at every auto-publish gate (flag off / wrong
  provider / not linked / already present / indeterminate).

## Test Plan

- `uv run pytest tests/test_cli/test_analyse_journey_auto_publish.py tests/test_growth_loops/test_upstream.py` → 29 passed.
- New regression test `TestPublishBundleOutputDirOverride` sets up a
  stale `skene/` dir alongside the fresh `skene-context/journey.yaml`,
  passes `output_dir` override, and asserts the pushed file list contains
  `skene-context/journey.yaml` and **not** `skene/growth-template.json`.
- Updated the auto-publish gating-matrix tests for the new `journey_path=`
  kwarg and assert the push is anchored to the journey's directory.

## Checklist

- [x] PR is focused on a single change (no unrelated refactoring or cleanup)
- [x] Tests added or updated for any behavioral change
- [ ] Documentation updated (if behavior, flags, config, or APIs changed) — no user-facing behavior/flags/API changed; the fix makes the documented behavior actually work
- [ ] Cursor plugin updated (if commands, skills, or core CLI behavior changed) — n/a
- [x] Linting and tests pass locally
- [x] No merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
