### PR TITLE
Store provider API key in OS keyring instead of clear text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "openai>=1.0",
     "anthropic>=0.40",
     "httpx>=0.27",
+    "keyring>=24.0",
     "sqlglot>=23.0",
     "tree-sitter>=0.23",
     "tree-sitter-javascript>=0.23",

--- a/src/skene/cli/config_manager.py
+++ b/src/skene/cli/config_manager.py
@@ -86,8 +86,15 @@ def get_provider_models(provider: str) -> list[str]:
 
 
 def save_config(config_path: Path, provider: str, model: str, api_key: str, base_url: str | None = None) -> None:
-    """Save configuration to a TOML file."""
+    """Save configuration to a TOML file.
+
+    The API key is never written to the file in clear text (CWE-312). It is
+    stored in the OS keyring instead; ``load_config`` reads it back from there.
+    If no keyring backend is available the key is not persisted and the user is
+    advised to use the ``SKENE_API_KEY`` environment variable.
+    """
     from skene.config import load_toml
+    from skene.secret_store import delete_api_key, set_api_key
 
     # Read existing config if it exists
     existing_config = {}
@@ -97,14 +104,25 @@ def save_config(config_path: Path, provider: str, model: str, api_key: str, base
         except Exception:
             pass  # If we can't read it, start fresh
 
+    # Store the API key securely in the OS keyring, never in the config file.
+    if api_key:
+        if not set_api_key(api_key):
+            console.print(
+                "[yellow]Warning: could not store the API key securely (no OS keyring "
+                "available). Set the SKENE_API_KEY environment variable instead.[/yellow]"
+            )
+    else:
+        # Empty key means the user cleared it — drop any previously stored secret.
+        delete_api_key()
+
     # Write TOML file manually
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     lines = ["# skene configuration"]
     lines.append("# See: https://github.com/skene-technologies/skene")
     lines.append("")
-    lines.append("# API key for LLM provider (can also use SKENE_API_KEY env var)")
-    lines.append(f'api_key = "{api_key}"')
+    lines.append("# API key for the LLM provider is stored in the OS keyring,")
+    lines.append("# not in this file. You can also set the SKENE_API_KEY env var.")
     lines.append("")
     lines.append("# LLM provider to use")
     lines.append(f'provider = "{provider}"')

--- a/src/skene/config.py
+++ b/src/skene/config.py
@@ -332,4 +332,12 @@ def load_config() -> Config:
     if output_dir := os.environ.get("SKENE_OUTPUT_DIR"):
         config.set("output_dir", output_dir)
 
+    # Fall back to the OS keyring for the API key when it was not provided by an
+    # environment variable or a (legacy clear-text) config file.
+    if not config.get("api_key"):
+        from skene.secret_store import get_api_key
+
+        if keyring_api_key := get_api_key():
+            config.set("api_key", keyring_api_key)
+
     return config

--- a/src/skene/secret_store.py
+++ b/src/skene/secret_store.py
@@ -1,0 +1,79 @@
+"""Secure storage for sensitive credentials via the OS keyring.
+
+The LLM provider API key must not be written to disk in clear text (CWE-312).
+Instead it is stored in the operating system keyring (macOS Keychain, Windows
+Credential Manager, or a Secret Service backend on Linux).
+
+All functions degrade gracefully: if no keyring backend is available (e.g. a
+headless CI box) they return ``False``/``None`` instead of raising, so callers
+can fall back to the ``SKENE_API_KEY`` environment variable.
+"""
+
+from __future__ import annotations
+
+# Keyring service/account under which the provider API key is stored.
+KEYRING_SERVICE = "skene"
+API_KEY_ACCOUNT = "api_key"
+
+
+def _keyring():
+    """Return the keyring module, or None if it (or a backend) is unavailable."""
+    try:
+        import keyring
+        from keyring.errors import NoKeyringError
+
+        # Touch the backend so misconfigured environments fail here, not later.
+        backend = keyring.get_keyring()
+        if backend is None:
+            return None
+        return keyring
+    except (ImportError, NoKeyringError, RuntimeError):
+        return None
+
+
+def set_api_key(api_key: str) -> bool:
+    """Store the provider API key in the OS keyring.
+
+    Returns True on success, False if no keyring backend is available.
+    """
+    kr = _keyring()
+    if kr is None:
+        return False
+    try:
+        kr.set_password(KEYRING_SERVICE, API_KEY_ACCOUNT, api_key)
+        return True
+    except Exception:
+        return False
+
+
+def get_api_key() -> str | None:
+    """Retrieve the provider API key from the OS keyring, or None if unavailable."""
+    kr = _keyring()
+    if kr is None:
+        return None
+    try:
+        value = kr.get_password(KEYRING_SERVICE, API_KEY_ACCOUNT)
+    except Exception:
+        return None
+    return value or None
+
+
+def delete_api_key() -> bool:
+    """Remove the stored provider API key from the OS keyring.
+
+    Returns True if a key was deleted, False otherwise (including when no
+    backend is available or no key was stored).
+    """
+    kr = _keyring()
+    if kr is None:
+        return False
+    try:
+        from keyring.errors import PasswordDeleteError
+
+        try:
+            kr.delete_password(KEYRING_SERVICE, API_KEY_ACCOUNT)
+            return True
+        except PasswordDeleteError:
+            return False
+    except Exception:
+        return False

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -97,3 +97,33 @@ def test_empty_key_deletes_stored_secret(fake_keyring, tmp_path):
     config_manager.save_config(config_path, "openai", "gpt-4o", "")
 
     assert secret_store.get_api_key() is None
+
+
+def test_real_keyring_round_trip(monkeypatch):
+    """Exercise the real OS keyring backend (no fake) on every platform.
+
+    Where a backend exists (e.g. Windows Credential Manager on CI), assert a
+    full set -> get -> delete round-trip. Where none exists (e.g. a headless
+    Linux runner), assert the graceful-degradation contract instead: the
+    wrappers return False/None rather than raising. Either way this validates
+    real behaviour, not the in-memory fake used elsewhere.
+
+    A throwaway service/account is used so a developer's real stored key is
+    never read, overwritten, or deleted by the test.
+    """
+    monkeypatch.setattr(secret_store, "KEYRING_SERVICE", "skene-test-ci")
+    monkeypatch.setattr(secret_store, "API_KEY_ACCOUNT", "roundtrip")
+
+    stored = secret_store.set_api_key("sk-ci-roundtrip")
+    try:
+        if stored:
+            # A usable backend is present: the secret must round-trip.
+            assert secret_store.get_api_key() == "sk-ci-roundtrip"
+        else:
+            # No backend available: must degrade quietly, not leak a value.
+            assert secret_store.get_api_key() is None
+    finally:
+        secret_store.delete_api_key()
+
+    # Cleanup is effective regardless of platform.
+    assert secret_store.get_api_key() is None

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -1,0 +1,99 @@
+"""Tests that the provider API key is stored in the keyring, not in clear text."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skene import config as config_module
+from skene import secret_store
+from skene.cli import config_manager
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch):
+    """Replace the OS keyring with an in-memory store for the duration of a test."""
+    store: dict[tuple[str, str], str] = {}
+
+    def fake_set(api_key: str) -> bool:
+        store[(secret_store.KEYRING_SERVICE, secret_store.API_KEY_ACCOUNT)] = api_key
+        return True
+
+    def fake_get() -> str | None:
+        return store.get((secret_store.KEYRING_SERVICE, secret_store.API_KEY_ACCOUNT))
+
+    def fake_delete() -> bool:
+        return store.pop((secret_store.KEYRING_SERVICE, secret_store.API_KEY_ACCOUNT), None) is not None
+
+    monkeypatch.setattr(secret_store, "set_api_key", fake_set)
+    monkeypatch.setattr(secret_store, "get_api_key", fake_get)
+    monkeypatch.setattr(secret_store, "delete_api_key", fake_delete)
+    return store
+
+
+def test_save_config_does_not_write_api_key_to_file(fake_keyring, tmp_path):
+    """The API key must never appear in the config file on disk (CWE-312)."""
+    config_path = tmp_path / "config"
+    save_key = "sk-super-secret-value"
+
+    config_manager.save_config(config_path, "openai", "gpt-4o", save_key)
+
+    contents = config_path.read_text()
+    assert save_key not in contents
+    assert "api_key" not in contents
+    # The secret lives in the (faked) keyring instead.
+    assert fake_keyring[(secret_store.KEYRING_SERVICE, secret_store.API_KEY_ACCOUNT)] == save_key
+
+
+def test_load_config_reads_api_key_from_keyring(fake_keyring, monkeypatch, tmp_path):
+    """load_config falls back to the keyring when no env/file key is present."""
+    monkeypatch.setattr(config_module, "find_user_config", lambda: None)
+    monkeypatch.setattr(config_module, "find_project_config", lambda: None)
+    monkeypatch.delenv("SKENE_API_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    secret_store.set_api_key("sk-from-keyring")
+    cfg = config_module.load_config()
+
+    assert cfg.api_key == "sk-from-keyring"
+
+
+def test_save_then_load_round_trip(fake_keyring, monkeypatch, tmp_path):
+    """A key saved via save_config is read back by load_config."""
+    monkeypatch.setattr(config_module, "find_user_config", lambda: None)
+    monkeypatch.setattr(config_module, "find_project_config", lambda: None)
+    monkeypatch.delenv("SKENE_API_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    config_path = tmp_path / "config"
+    config_manager.save_config(config_path, "anthropic", "claude-sonnet-4-5", "sk-roundtrip")
+
+    monkeypatch.setattr(config_module, "find_user_config", lambda: Path(config_path))
+    cfg = config_module.load_config()
+
+    assert cfg.api_key == "sk-roundtrip"
+    assert cfg.provider == "anthropic"
+
+
+def test_env_var_takes_precedence_over_keyring(fake_keyring, monkeypatch, tmp_path):
+    """SKENE_API_KEY overrides whatever is stored in the keyring."""
+    monkeypatch.setattr(config_module, "find_user_config", lambda: None)
+    monkeypatch.setattr(config_module, "find_project_config", lambda: None)
+    monkeypatch.chdir(tmp_path)
+
+    secret_store.set_api_key("sk-keyring")
+    monkeypatch.setenv("SKENE_API_KEY", "sk-env")
+    cfg = config_module.load_config()
+
+    assert cfg.api_key == "sk-env"
+
+
+def test_empty_key_deletes_stored_secret(fake_keyring, tmp_path):
+    """Saving an empty key clears any previously stored secret."""
+    secret_store.set_api_key("sk-old")
+    config_path = tmp_path / "config"
+
+    config_manager.save_config(config_path, "openai", "gpt-4o", "")
+
+    assert secret_store.get_api_key() is None

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -386,12 +395,69 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -489,6 +555,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
     { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
     { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -597,6 +681,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -829,6 +922,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -962,6 +1064,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -981,6 +1096,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "keyring" },
     { name = "loguru" },
     { name = "openai" },
     { name = "pydantic" },
@@ -1013,6 +1129,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.0" },
+    { name = "keyring", specifier = ">=24.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "openai", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1243,4 +1360,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#7](https://github.com/SkeneTechnologies/skene/security/code-scanning/7) — `py/clear-text-storage-sensitive-data` (CWE-312, high). `save_config` was writing the LLM provider `api_key` into the TOML config file in clear text.

The key is now stored in the OS keyring (macOS Keychain / Windows Credential Manager / Linux Secret Service) and never written to disk.

## Changes

- **`src/skene/secret_store.py`** (new) — thin wrapper over the `keyring` library (`set_api_key` / `get_api_key` / `delete_api_key`). Degrades gracefully (returns `False`/`None`) when no keyring backend is available rather than raising.
- **`src/skene/cli/config_manager.py`** — `save_config` stores the key in the keyring and no longer writes `api_key` to the file (removes the flagged sink). Warns and points at `SKENE_API_KEY` when no backend exists; clears the stored secret when the key is blanked. Legacy clear-text keys in an existing file are dropped on the next save.
- **`src/skene/config.py`** — `load_config` falls back to the keyring when `api_key` is not set via `SKENE_API_KEY` or a config file. Precedence: **env > config file (legacy) > keyring**, so existing users aren't broken.
- **`pyproject.toml` / `uv.lock`** — add `keyring>=24.0`.
- **`tests/test_secret_store.py`** (new) — no clear-text key on disk, keyring read-back, save→load round-trip, env-var precedence, clear-on-empty.

## Verification

- New tests + existing `test_config.py`, `test_cli/`, `test_upstream.py` pass (45 tests).
- `ruff` clean; keyring resolves to the macOS backend locally.

## Notes

On a headless Linux CI runner the Secret Service backend may be absent; the code handles that by returning `None` so loading won't crash. Migration is lazy — existing clear-text keys keep working and are moved into the keyring on the next `skene config` save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)