### PR TITLE
ci: run test suite on Windows in addition to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,11 @@ jobs:
       run: ruff format --check .
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
## Summary

Adds `windows-latest` to the CI test matrix so the suite runs on real Windows on every PR, alongside the existing Linux jobs.

```yaml
test:
  runs-on: ${{ matrix.os }}
  strategy:
    fail-fast: false
    matrix:
      os: [ubuntu-latest, windows-latest]
      python-version: ["3.11", "3.12", "3.13"]
```

## Why

Cross-platform behaviour — notably the `sys.platform != "win32"` branches in config file handling (`_set_config_permissions`, `_write_config_toml`) and OS keyring backend selection — was previously only exercised on Linux. This gives genuine Windows coverage without needing local Windows access.

`fail-fast: false` keeps every OS/Python combination running even when one fails, so a single failure doesn't mask others.

## Notes

This is infrastructure-only — no production code changes. `uv` and `setup-uv` already support Windows runners, so no other edits are required. Independent of the keyring fix in #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
