### PR TITLE
Feat/add postgresql connection

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -123,6 +123,7 @@ exclude_folders = ["tests", "vendor"]
 | `SKENE_OUTPUT_DIR` | Overrides config `output_dir` (sticky detection skipped when set) | `./skene-context` |
 | `SKENE_DEBUG` | Enable debug mode | `true` |
 | `SKENE_UPSTREAM_API_KEY` | API key for upstream authentication | `sk-upstream-...` |
+| `SKENE_DB_URL` | PostgreSQL connection string for `analyse-journey` live schema introspection | `postgresql://user:pass@localhost:5432/mydb` |
 | `LMSTUDIO_BASE_URL` | LM Studio server URL | `http://localhost:1234/v1` |
 | `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434/v1` |
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -123,7 +123,7 @@ exclude_folders = ["tests", "vendor"]
 | `SKENE_OUTPUT_DIR` | Overrides config `output_dir` (sticky detection skipped when set) | `./skene-context` |
 | `SKENE_DEBUG` | Enable debug mode | `true` |
 | `SKENE_UPSTREAM_API_KEY` | API key for upstream authentication | `sk-upstream-...` |
-| `SKENE_DB_URL` | PostgreSQL connection string for `analyse-journey` live schema introspection | `postgresql://user:pass@localhost:5432/mydb` |
+| `SKENE_DB_URL` | PostgreSQL connection string for `analyse-journey` live schema introspection. Skene introspects all user-defined schemas (excluding `pg_catalog`, `information_schema`, `pg_toast`, and `pg_*` schemas). | `postgresql://user:pass@localhost:5432/mydb` |
 | `LMSTUDIO_BASE_URL` | LM Studio server URL | `http://localhost:1234/v1` |
 | `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434/v1` |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -49,7 +49,7 @@ skene validate MANIFEST
 
 skene analyse-journey [PATH]
    Generate a journey.yaml describing the user lifecycle using parallel code and schema agents.
-   Flags: --schema-dir, --db-url (PostgreSQL DSN, also SKENE_DB_URL env var), -o/--output, --product-name, --api-key, -p/--provider, -m/--model, --base-url, --schema-max-turns, --code-max-turns, --classify-concurrency, --no-specialize, -q/--quiet, --debug, --no-fallback
+    Flags: --schema-dir, --db-url (PostgreSQL DSN, also SKENE_DB_URL env var; introspects all user schemas excluding pg_catalog, information_schema, pg_toast, pg_*), -o/--output, --product-name, --api-key, -p/--provider, -m/--model, --base-url, --schema-max-turns, --code-max-turns, --classify-concurrency, --no-specialize, -q/--quiet, --debug, --no-fallback
 
 ## LLM Providers
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -45,7 +45,11 @@ skene config
   Manage configuration. --init creates config file, --show displays current values, no flags for interactive editing.
 
 skene validate MANIFEST
-  Validate a growth-manifest.json against the schema.
+   Validate a growth-manifest.json against the schema.
+
+skene analyse-journey [PATH]
+   Generate a journey.yaml describing the user lifecycle using parallel code and schema agents.
+   Flags: --schema-dir, --db-url (PostgreSQL DSN, also SKENE_DB_URL env var), -o/--output, --product-name, --api-key, -p/--provider, -m/--model, --base-url, --schema-max-turns, --code-max-turns, --classify-concurrency, --no-specialize, -q/--quiet, --debug, --no-fallback
 
 ## LLM Providers
 
@@ -65,7 +69,7 @@ Priority: user config < project config < env vars < CLI flags
 
 Options: api_key, provider, model, base_url, output_dir, debug, exclude_folders, upstream
 
-Environment variables: SKENE_API_KEY, SKENE_PROVIDER, SKENE_BASE_URL, SKENE_OUTPUT_DIR, SKENE_DEBUG, SKENE_UPSTREAM_API_KEY, LMSTUDIO_BASE_URL, OLLAMA_BASE_URL
+Environment variables: SKENE_API_KEY, SKENE_PROVIDER, SKENE_BASE_URL, SKENE_OUTPUT_DIR, SKENE_DEBUG, SKENE_UPSTREAM_API_KEY, SKENE_DB_URL, LMSTUDIO_BASE_URL, OLLAMA_BASE_URL
 
 ## Output Files
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,6 +59,62 @@ See the [analyze guide](../guides/analyze.md) for detailed usage.
 
 ---
 
+## `analyse-journey`
+
+Generate a `journey.yaml` describing the user lifecycle of a product.
+
+Uses two parallel LLM agents — one analyzing the codebase filesystem, one analyzing the database schema — to discover user-facing milestones and assemble them into a validated Customer Journey map across seven lifecycle stages: discovery, onboarding, activation, engagement, retention, expansion, and virality.
+
+```
+skene analyse-journey [PATH] [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `PATH` | `.` | Path to codebase directory to analyse (omit for current directory) |
+
+### Options
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--schema-dir PATH` | | | Directory of pre-exported `*.sql` files for the schema agent |
+| `--db-url TEXT` | | | PostgreSQL connection string for live schema introspection (alternative to `--schema-dir`; also `SKENE_DB_URL` env var) |
+| `--output PATH` | `-o` | `./skene-context/journey.yaml` | Output path for `journey.yaml` |
+| `--product-name TEXT` | | | Product name in the output (default: inferred from repo directory name, DB name, or schema dir name) |
+| `--api-key TEXT` | | `$SKENE_API_KEY` or config | API key for the LLM provider |
+| `--provider TEXT` | `-p` | config value | LLM provider: `openai`, `gemini`, `anthropic`/`claude`, `lmstudio`, `ollama`, `generic`, `skene` |
+| `--model TEXT` | `-m` | provider default | LLM model name |
+| `--base-url TEXT` | | `$SKENE_BASE_URL` or config | Base URL for API endpoint |
+| `--schema-max-turns INT` | | `150` | Maximum agent turns for the schema agent (range: 1–500) |
+| `--code-max-turns INT` | | `200` | Maximum agent turns for the code agent (range: 1–500) |
+| `--classify-concurrency INT` | | `8` | Parallel classifier requests (range: 1–64) |
+| `--no-specialize` | | `false` | Skip stage specialization; use canonical stage vocabulary |
+| `--quiet` | `-q` | `false` | Suppress status messages; show only errors and final results |
+| `--debug` | | `false` | Show diagnostic messages and log all LLM input/output |
+| `--no-fallback` | | `false` | Disable model fallback on rate limits; retry same model instead |
+
+### Schema sources
+
+The schema agent requires one of two inputs — **never both**:
+
+- **SQL files** (`--schema-dir`): Provide a directory of pre-exported `*.sql` files defining tables, views, constraints, and indexes.
+- **Live database** (`--db-url`): Connect directly to a running PostgreSQL database. Skene introspects the schema at runtime. Credentials are never stored.
+
+`--schema-dir` and `--db-url` are mutually exclusive. At least one of `PATH`, `--schema-dir`, or `--db-url` must be provided.
+
+### Behavior notes
+
+- Requires a configured LLM (API key + provider). Local providers (`lmstudio`, `ollama`, `generic`) do not require an API key.
+- The `generic` provider requires `--base-url`.
+- When `--db-url` is used without `--product-name`, the database name is extracted from the connection string for the product name.
+- When run from the TUI with a linked Skene Cloud workspace, the journey is automatically published on first run.
+
+See the CLI help output (`skene analyse-journey --help`) for detailed usage.
+
+---
+
 ## `plan`
 
 Generate a growth plan using the Council of Growth Engineers methodology.
@@ -367,12 +423,13 @@ See the [features guide](../guides/features.md) for detailed usage.
 
 | Variable | Used by | Description |
 |----------|---------|-------------|
-| `SKENE_API_KEY` | `analyze`, `plan`, `build`, `status` | API key for the LLM provider. Equivalent to `--api-key`. |
-| `SKENE_BASE_URL` | `analyze`, `plan`, `build` | Base URL for OpenAI-compatible endpoints. Equivalent to `--base-url`. |
+| `SKENE_API_KEY` | `analyze`, `plan`, `build`, `status`, `analyse-journey` | API key for the LLM provider. Equivalent to `--api-key`. |
+| `SKENE_BASE_URL` | `analyze`, `plan`, `build`, `analyse-journey` | Base URL for OpenAI-compatible endpoints. Equivalent to `--base-url`. |
 | `SKENE_PROVIDER` | config loading | LLM provider override at the environment level. |
 | `SKENE_OUTPUT_DIR` | all commands | Override `output_dir` for commands that have no dedicated flag (primarily `push`). |
 | `SKENE_UPSTREAM_API_KEY` | `push`, `login` | API key for upstream authentication. |
 | `SKENE_DEBUG` | all commands | Enable debug mode (`true`/`false`). |
+| `SKENE_DB_URL` | `analyse-journey` | PostgreSQL connection string for live schema introspection. Equivalent to `--db-url`. |
 
 ---
 
@@ -431,4 +488,13 @@ uvx skene features export --format markdown -o features.md
 
 # Quick preview (no API key, just run analyze without a key)
 uvx skene analyze .
+
+# Analyse user journey with SQL schema files
+uvx skene analyse-journey ./my-app --schema-dir ./schemas
+
+# Analyse user journey with a live database
+uvx skene analyse-journey --db-url "postgresql://user:pass@localhost:5432/mydb"
+
+# Journey analysis with custom output
+uvx skene analyse-journey ./my-app --schema-dir ./schemas -o ./output/journey.yaml
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -100,7 +100,7 @@ skene analyse-journey [PATH] [OPTIONS]
 The schema agent requires one of two inputs — **never both**:
 
 - **SQL files** (`--schema-dir`): Provide a directory of pre-exported `*.sql` files defining tables, views, constraints, and indexes.
-- **Live database** (`--db-url`): Connect directly to a running PostgreSQL database. Skene introspects the schema at runtime. Credentials are never stored.
+- **Live database** (`--db-url`): Connect directly to a running PostgreSQL database. Skene introspects all user-defined schemas at runtime (excluding `pg_catalog`, `information_schema`, `pg_toast`, and any schema prefixed with `pg_`). Credentials are never stored.
 
 `--schema-dir` and `--db-url` are mutually exclusive. At least one of `PATH`, `--schema-dir`, or `--db-url` must be provided.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -102,7 +102,7 @@ The schema agent requires one of two inputs — **never both**:
 - **SQL files** (`--schema-dir`): Provide a directory of pre-exported `*.sql` files defining tables, views, constraints, and indexes.
 - **Live database** (`--db-url`): Connect directly to a running PostgreSQL database. Skene introspects all user-defined schemas at runtime (excluding `pg_catalog`, `information_schema`, `pg_toast`, and any schema prefixed with `pg_`). Credentials are never stored.
 
-`--schema-dir` and `--db-url` are mutually exclusive. At least one of `PATH`, `--schema-dir`, or `--db-url` must be provided.
+`--schema-dir` and `--db-url` are mutually exclusive. At least one of `PATH`, `--schema-dir`, or `--db-url` must be provided. When `PATH` is omitted, only the schema agent runs (no code agent).
 
 ### Behavior notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "tree-sitter>=0.23",
     "tree-sitter-javascript>=0.23",
     "tree-sitter-typescript>=0.23",
+    "psycopg[binary]>=3.2",
 ]
 
 [project.optional-dependencies]

--- a/src/skene/analyzers/journey/pipeline.py
+++ b/src/skene/analyzers/journey/pipeline.py
@@ -32,6 +32,7 @@ from skene.analyzers.journey.models import Journey
 from skene.analyzers.journey.schema_agent import run_schema_agent
 from skene.analyzers.journey.specialize import specialize_stages
 from skene.analyzers.journey.stages import STAGES, StageDef
+from skene.analyzers.schema_parsers.models import SchemaIndex
 from skene.llm.base import LLMClient
 from skene.output import status, warning
 
@@ -47,23 +48,31 @@ class JourneyPipelineConfig:
     - **code only** (``schema_dir is None``): skip schema agent.
     - **schema only** (``repo_root is None``): skip code agent AND skip
       stage specialization (no README to read). Stages stay canonical.
+
+    ``schema_index`` is an optional pre-built :class:`SchemaIndex` from a
+    live database (via ``--db-url``). When set, it replaces ``schema_dir``
+    as the schema source.
     """
 
     repo_root: Path | None
-    schema_dir: Path | None
-    product_name: str
+    schema_dir: Path | None = None
+    schema_index: SchemaIndex | None = None
+    product_name: str = "Product"
     classify_concurrency: int = 8
     schema_max_turns: int = 150
     code_max_turns: int = 200
     specialize: bool = True
 
     def __post_init__(self) -> None:
-        if self.repo_root is None and self.schema_dir is None:
-            raise ValueError("JourneyPipelineConfig requires at least one of repo_root or schema_dir")
+        if self.repo_root is None and self.schema_dir is None and self.schema_index is None:
+            raise ValueError("JourneyPipelineConfig requires at least one of repo_root, schema_dir, or schema_index")
+        if self.schema_dir is not None and self.schema_index is not None:
+            raise ValueError("JourneyPipelineConfig: schema_dir and schema_index are mutually exclusive")
 
 
 def _describe_mode(cfg: JourneyPipelineConfig) -> str:
-    if cfg.repo_root is not None and cfg.schema_dir is not None:
+    has_schema = cfg.schema_dir is not None or cfg.schema_index is not None
+    if cfg.repo_root is not None and has_schema:
         return "code+schema"
     if cfg.repo_root is not None:
         return "code-only"
@@ -90,6 +99,14 @@ async def run_journey_pipeline(cfg: JourneyPipelineConfig, llm: LLMClient) -> Jo
                 cfg.schema_dir,
                 llm=llm,
                 max_turns=cfg.schema_max_turns,
+            )
+        )
+    elif cfg.schema_index is not None:
+        schema_task = asyncio.create_task(
+            run_schema_agent(
+                llm=llm,
+                max_turns=cfg.schema_max_turns,
+                schema_index=cfg.schema_index,
             )
         )
     if cfg.repo_root is not None:

--- a/src/skene/analyzers/journey/schema_agent.py
+++ b/src/skene/analyzers/journey/schema_agent.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from skene.analyzers.journey.candidate import CandidateMilestone
 from skene.analyzers.journey.tools.schema_tools import SchemaToolset
+from skene.analyzers.schema_parsers.models import SchemaIndex
 from skene.analyzers.schema_parsers.supabase_sql import parse_schema_dir
 from skene.llm.base import LLMClient
 from skene.output import status
@@ -78,18 +79,43 @@ tool call) and stop.
 
 
 async def run_schema_agent(
-    schema_dir: Path,
+    schema_dir: Path | None = None,
+    *,
     llm: LLMClient,
     max_turns: int = 150,
+    schema_index: SchemaIndex | None = None,
 ) -> list[CandidateMilestone]:
-    """Run the schema agent. Returns the list of emitted candidates."""
-    status(f"Schema agent: parsing {schema_dir}")
-    index = parse_schema_dir(schema_dir)
-    table_count = sum(len(t) for t in index.files.values())
-    status(
-        f"Schema agent: parsed {len(index.files)} files, {table_count} tables "
-        f"({len(index.application_files())} application)"
-    )
+    """Run the schema agent. Returns the list of emitted candidates.
+
+    Parameters
+    ----------
+    schema_dir:
+        Path to a directory of ``*.sql`` files. Mutually exclusive with
+        ``schema_index`` — provide exactly one.
+    llm:
+        The LLM client to use for the agent.
+    max_turns:
+        Maximum agent turns.
+    schema_index:
+        A pre-built :class:`SchemaIndex` (e.g. from a live database via
+        ``--db-url``). When provided, ``schema_dir`` is ignored.
+    """
+    if schema_index is None:
+        if schema_dir is None:
+            raise ValueError("run_schema_agent requires either schema_dir or schema_index")
+        status(f"Schema agent: parsing {schema_dir}")
+        index = parse_schema_dir(schema_dir)
+        table_count = sum(len(t) for t in index.files.values())
+        status(
+            f"Schema agent: parsed {len(index.files)} files, {table_count} tables "
+            f"({len(index.application_files())} application)"
+        )
+    else:
+        index = schema_index
+        table_count = sum(len(t) for t in index.files.values())
+        status(
+            f"Schema agent: using live DB schema, {table_count} tables ({len(index.application_files())} application)"
+        )
 
     collector: list[CandidateMilestone] = []
     toolset = SchemaToolset(index, collector)

--- a/src/skene/analyzers/schema_parsers/__init__.py
+++ b/src/skene/analyzers/schema_parsers/__init__.py
@@ -8,6 +8,7 @@ from skene.analyzers.schema_parsers.models import (
     SchemaIndex,
     TableInfo,
 )
+from skene.analyzers.schema_parsers.postgres_live import introspect_db
 from skene.analyzers.schema_parsers.supabase_sql import (
     is_supabase_internal,
     parse_schema_dir,
@@ -20,6 +21,7 @@ __all__ = [
     "SchemaFileInfo",
     "SchemaIndex",
     "TableInfo",
+    "introspect_db",
     "is_supabase_internal",
     "parse_schema_dir",
 ]

--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -27,6 +27,24 @@ from skene.output import debug
 # relkind filter: ordinary tables, views, materialized views.
 _RELKIND_FILTER = "('r', 'v', 'm')"
 
+# System schemas to exclude from introspection.
+_SYSTEM_SCHEMAS = ("pg_catalog", "information_schema", "pg_toast")
+
+
+def _discover_user_schemas(cur: Any) -> list[str]:
+    """Return user-defined schema names, excluding system and extension schemas."""
+    cur.execute(
+        """\
+        SELECT nspname
+        FROM pg_namespace
+        WHERE nspname NOT IN %s
+          AND nspname NOT LIKE 'pg_%%'
+        ORDER BY nspname
+    """,
+        (_SYSTEM_SCHEMAS,),
+    )
+    return [row["nspname"] for row in cur.fetchall()]
+
 
 def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
     """Connect to *db_url*, introspect the schema, return a :class:`SchemaIndex`.
@@ -43,35 +61,24 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
     with psycopg.connect(db_url, connect_timeout=connect_timeout, row_factory=dict_row) as conn:
         tables_by_file: dict[str, dict[str, TableInfo]] = {}
 
-        # --- 1. Collect tables (names + primary keys) ---
-        tables_query = """\
-            SELECT c.relname AS table_name,
-                   i.indisprimary AS is_pk,
-                   array_agg(a.attname ORDER BY array_position(i.indkey, a.attnum)) AS pk_columns
-            FROM pg_class c
-            JOIN pg_namespace n ON n.oid = c.relnamespace
-            JOIN pg_index i ON i.indrelid = c.oid
-            JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
-            WHERE c.relkind IN _RELKIND_PLACEHOLDER
-              AND n.nspname = 'public'
-            GROUP BY c.relname, i.indisprimary, a.attname
-        """
-        # We need a different approach because array_agg with ORDER BY
-        # inside a GROUP BY on indisprimary creates ambiguity.
-        # Use a simpler query and handle PK columns separately.
+        # --- 0. Discover user schemas (exclude pg_*, information_schema) ---
+        with conn.cursor() as cur:
+            user_schemas = _discover_user_schemas(cur)
 
+        if not user_schemas:
+            return index
+
+        # --- 1. Collect tables (names + primary keys) ---
         tables_query = """\
             SELECT DISTINCT c.relname AS table_name
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relkind IN _RELKIND_PLACEHOLDER
-              AND n.nspname = 'public'
+            WHERE c.relkind IN %s
+              AND n.nspname = ANY(%s)
             ORDER BY c.relname
         """
-        tables_query = tables_query.replace("_RELKIND_PLACEHOLDER", _RELKIND_FILTER)
-
         with conn.cursor() as cur:
-            cur.execute(tables_query)
+            cur.execute(tables_query, (_RELKIND_FILTER, user_schemas))
             table_names: list[str] = [row["table_name"] for row in cur.fetchall()]
 
         if not table_names:
@@ -88,11 +95,11 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             JOIN pg_index ix ON ix.indrelid = c.oid AND ix.indisprimary
             JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(ix.indkey)
             WHERE c.relname = ANY(%s)
-              AND n.nspname = 'public'
+              AND n.nspname = ANY(%s)
             GROUP BY c.relname
         """
         with conn.cursor() as cur:
-            cur.execute(pk_query, (table_names,))
+            cur.execute(pk_query, (table_names, user_schemas))
             pk_map: dict[str, list[str]] = {row["table_name"]: row["pk_columns"] for row in cur.fetchall()}
 
         # 2b. Columns per table
@@ -100,11 +107,11 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             SELECT table_name, column_name, data_type, is_nullable, column_default
             FROM information_schema.columns
             WHERE table_name = ANY(%s)
-              AND table_schema = 'public'
+              AND table_schema = ANY(%s)
             ORDER BY table_name, ordinal_position
         """
         with conn.cursor() as cur:
-            cur.execute(col_query, (table_names,))
+            cur.execute(col_query, (table_names, user_schemas))
             # Group by table
             cols_by_table: dict[str, list[dict[str, Any]]] = {}
             for row in cur.fetchall():
@@ -125,11 +132,11 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
              AND ccu.table_schema = tc.table_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND tc.table_name = ANY(%s)
-              AND tc.table_schema = 'public'
+              AND tc.table_schema = ANY(%s)
             GROUP BY tc.table_name, ccu.table_name
         """
         with conn.cursor() as cur:
-            cur.execute(fk_query, (table_names,))
+            cur.execute(fk_query, (table_names, user_schemas))
             fk_map: dict[str, list[dict[str, Any]]] = {}
             for row in cur.fetchall():
                 fk_map.setdefault(row["table_name"], []).append(row)
@@ -145,14 +152,13 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             JOIN pg_index ix ON ix.indexrelid = i.oid
             JOIN pg_namespace n ON n.oid = t.relnamespace
             JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
-            WHERE t.relkind IN _IDXRELKIND_PLACEHOLDER
+            WHERE t.relkind IN %s
               AND t.relname = ANY(%s)
-              AND n.nspname = 'public'
+              AND n.nspname = ANY(%s)
             GROUP BY t.relname, i.relname, ix.indisunique
         """
-        idx_query = idx_query.replace("_IDXRELKIND_PLACEHOLDER", "('r', 'v', 'm')")
         with conn.cursor() as cur:
-            cur.execute(idx_query, (table_names,))
+            cur.execute(idx_query, ((_RELKIND_FILTER,), table_names, user_schemas))
             idx_map: dict[str, list[dict[str, Any]]] = {}
             for row in cur.fetchall():
                 idx_map.setdefault(row["table_name"], []).append(row)

--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -39,9 +39,9 @@ from skene.analyzers.schema_parsers.models import (
 )
 from skene.output import debug
 
-# relkind filter: ordinary tables, views, materialized views.
+# relkind filter: ordinary tables, partitioned tables, views, materialized views.
 # Injected directly into SQL (static string, never user input).
-_RELKIND_FILTER = "('r', 'v', 'm')"
+_RELKIND_FILTER = "('r', 'p', 'v', 'm')"
 
 
 def _discover_user_schemas(cur: Any) -> list[str]:
@@ -80,10 +80,12 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
 
         # --- 1. Collect tables (names + primary keys) ---
         tables_query = f"""\
-            SELECT DISTINCT c.relname AS table_name
+            SELECT c.relname AS table_name
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN pg_inherits i ON i.inhrelid = c.oid
             WHERE c.relkind IN {_RELKIND_FILTER}
+              AND i.inhrelid IS NULL
               AND n.nspname = ANY(%s)
             ORDER BY c.relname
         """
@@ -167,7 +169,9 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             JOIN pg_class i ON i.oid = ix.indexrelid
             JOIN pg_namespace n ON n.oid = t.relnamespace
             JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+            LEFT JOIN pg_inherits pi ON pi.inhrelid = t.oid
             WHERE t.relkind IN {_RELKIND_FILTER}
+              AND pi.inhrelid IS NULL
               AND t.relname = ANY(%s)
               AND n.nspname = ANY(%s)
             GROUP BY t.relname, i.relname, ix.indisunique

--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -10,10 +10,25 @@ or log line.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import psycopg
 from psycopg.rows import dict_row
+
+
+def _pg_array_to_list(val: Any) -> list[str]:
+    """Convert a PostgreSQL array string like '{a,b,c}' to ['a','b','c']."""
+    if val is None:
+        return []
+    if isinstance(val, (list, tuple)):
+        return [str(v) for v in val]
+    # Strip outer braces
+    inner = str(val).strip("{}")
+    if not inner:
+        return []
+    # Split on commas, strip quotes and whitespace
+    return [item.strip().strip("'") for item in inner.split(",") if item.strip()]
 
 from skene.analyzers.schema_parsers.models import (
     ColumnInfo,
@@ -25,24 +40,19 @@ from skene.analyzers.schema_parsers.models import (
 from skene.output import debug
 
 # relkind filter: ordinary tables, views, materialized views.
+# Injected directly into SQL (static string, never user input).
 _RELKIND_FILTER = "('r', 'v', 'm')"
-
-# System schemas to exclude from introspection.
-_SYSTEM_SCHEMAS = ("pg_catalog", "information_schema", "pg_toast")
 
 
 def _discover_user_schemas(cur: Any) -> list[str]:
     """Return user-defined schema names, excluding system and extension schemas."""
-    cur.execute(
-        """\
+    cur.execute("""\
         SELECT nspname
         FROM pg_namespace
-        WHERE nspname NOT IN %s
+        WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
           AND nspname NOT LIKE 'pg_%%'
         ORDER BY nspname
-    """,
-        (_SYSTEM_SCHEMAS,),
-    )
+    """)
     return [row["nspname"] for row in cur.fetchall()]
 
 
@@ -69,16 +79,16 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             return index
 
         # --- 1. Collect tables (names + primary keys) ---
-        tables_query = """\
+        tables_query = f"""\
             SELECT DISTINCT c.relname AS table_name
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relkind IN %s
+            WHERE c.relkind IN {_RELKIND_FILTER}
               AND n.nspname = ANY(%s)
             ORDER BY c.relname
         """
         with conn.cursor() as cur:
-            cur.execute(tables_query, (_RELKIND_FILTER, user_schemas))
+            cur.execute(tables_query, (user_schemas,))
             table_names: list[str] = [row["table_name"] for row in cur.fetchall()]
 
         if not table_names:
@@ -87,7 +97,7 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
         # --- 2. Collect all data in parallel-ish queries (single connection, sequential) ---
 
         # 2a. Primary keys per table
-        pk_query = """\
+        pk_query = f"""\
             SELECT c.relname AS table_name,
                    array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS pk_columns
             FROM pg_class c
@@ -100,7 +110,9 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
         """
         with conn.cursor() as cur:
             cur.execute(pk_query, (table_names, user_schemas))
-            pk_map: dict[str, list[str]] = {row["table_name"]: row["pk_columns"] for row in cur.fetchall()}
+            pk_map: dict[str, list[str]] = {
+                row["table_name"]: _pg_array_to_list(row["pk_columns"]) for row in cur.fetchall()
+            }
 
         # 2b. Columns per table
         col_query = """\
@@ -139,29 +151,34 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             cur.execute(fk_query, (table_names, user_schemas))
             fk_map: dict[str, list[dict[str, Any]]] = {}
             for row in cur.fetchall():
-                fk_map.setdefault(row["table_name"], []).append(row)
+                r = dict(row)  # Row → mutable dict
+                r["columns"] = _pg_array_to_list(r["columns"])
+                r["references_columns"] = _pg_array_to_list(r["references_columns"])
+                fk_map.setdefault(r["table_name"], []).append(r)
 
         # 2d. Indexes
-        idx_query = """\
+        idx_query = f"""\
             SELECT t.relname AS table_name,
                    i.relname AS index_name,
                    array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns,
                    ix.indisunique AS is_unique
             FROM pg_class t
+            JOIN pg_index ix ON ix.indrelid = t.oid
             JOIN pg_class i ON i.oid = ix.indexrelid
-            JOIN pg_index ix ON ix.indexrelid = i.oid
             JOIN pg_namespace n ON n.oid = t.relnamespace
             JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
-            WHERE t.relkind IN %s
+            WHERE t.relkind IN {_RELKIND_FILTER}
               AND t.relname = ANY(%s)
               AND n.nspname = ANY(%s)
             GROUP BY t.relname, i.relname, ix.indisunique
         """
         with conn.cursor() as cur:
-            cur.execute(idx_query, ((_RELKIND_FILTER,), table_names, user_schemas))
+            cur.execute(idx_query, (table_names, user_schemas))
             idx_map: dict[str, list[dict[str, Any]]] = {}
             for row in cur.fetchall():
-                idx_map.setdefault(row["table_name"], []).append(row)
+                r = dict(row)
+                r["columns"] = _pg_array_to_list(r["columns"])
+                idx_map.setdefault(r["table_name"], []).append(r)
 
         # --- 3. Assemble TableInfo objects ---
         for tname in table_names:

--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -157,7 +157,6 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
              AND tc.table_schema = kcu.table_schema
             JOIN information_schema.constraint_column_usage ccu
               ON ccu.constraint_name = tc.constraint_name
-             AND ccu.table_schema = tc.table_schema
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND tc.table_name = ANY(%s)
               AND tc.table_schema = ANY(%s)

--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -1,0 +1,211 @@
+"""Introspect a live PostgreSQL database and return a SchemaIndex.
+
+Uses psycopg3 (sync API) to query the PostgreSQL catalog in a small number
+of set-returning queries, then assembles the results into the same
+:class:`SchemaIndex` that the SQL-file parser produces.
+
+Never raises the raw connection string or password in an exception message
+or log line.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from skene.analyzers.schema_parsers.models import (
+    ColumnInfo,
+    ForeignKey,
+    IndexInfo,
+    SchemaIndex,
+    TableInfo,
+)
+from skene.output import debug
+
+# relkind filter: ordinary tables, views, materialized views.
+_RELKIND_FILTER = "('r', 'v', 'm')"
+
+
+def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
+    """Connect to *db_url*, introspect the schema, return a :class:`SchemaIndex`.
+
+    Parameters
+    ----------
+    db_url:
+        A complete PostgreSQL connection string (libpq URL or keyword DSN).
+    connect_timeout:
+        Seconds to wait for the TCP connection to be established.
+    """
+    index = SchemaIndex()
+
+    with psycopg.connect(db_url, connect_timeout=connect_timeout, row_factory=dict_row) as conn:
+        tables_by_file: dict[str, dict[str, TableInfo]] = {}
+
+        # --- 1. Collect tables (names + primary keys) ---
+        tables_query = """\
+            SELECT c.relname AS table_name,
+                   i.indisprimary AS is_pk,
+                   array_agg(a.attname ORDER BY array_position(i.indkey, a.attnum)) AS pk_columns
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_index i ON i.indrelid = c.oid
+            JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
+            WHERE c.relkind IN _RELKIND_PLACEHOLDER
+              AND n.nspname = 'public'
+            GROUP BY c.relname, i.indisprimary, a.attname
+        """
+        # We need a different approach because array_agg with ORDER BY
+        # inside a GROUP BY on indisprimary creates ambiguity.
+        # Use a simpler query and handle PK columns separately.
+
+        tables_query = """\
+            SELECT DISTINCT c.relname AS table_name
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind IN _RELKIND_PLACEHOLDER
+              AND n.nspname = 'public'
+            ORDER BY c.relname
+        """
+        tables_query = tables_query.replace("_RELKIND_PLACEHOLDER", _RELKIND_FILTER)
+
+        with conn.cursor() as cur:
+            cur.execute(tables_query)
+            table_names: list[str] = [row["table_name"] for row in cur.fetchall()]
+
+        if not table_names:
+            return index
+
+        # --- 2. Collect all data in parallel-ish queries (single connection, sequential) ---
+
+        # 2a. Primary keys per table
+        pk_query = """\
+            SELECT c.relname AS table_name,
+                   array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS pk_columns
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_index ix ON ix.indrelid = c.oid AND ix.indisprimary
+            JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(ix.indkey)
+            WHERE c.relname = ANY(%s)
+              AND n.nspname = 'public'
+            GROUP BY c.relname
+        """
+        with conn.cursor() as cur:
+            cur.execute(pk_query, (table_names,))
+            pk_map: dict[str, list[str]] = {row["table_name"]: row["pk_columns"] for row in cur.fetchall()}
+
+        # 2b. Columns per table
+        col_query = """\
+            SELECT table_name, column_name, data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_name = ANY(%s)
+              AND table_schema = 'public'
+            ORDER BY table_name, ordinal_position
+        """
+        with conn.cursor() as cur:
+            cur.execute(col_query, (table_names,))
+            # Group by table
+            cols_by_table: dict[str, list[dict[str, Any]]] = {}
+            for row in cur.fetchall():
+                cols_by_table.setdefault(row["table_name"], []).append(row)
+
+        # 2c. Foreign keys
+        fk_query = """\
+            SELECT tc.table_name,
+                   array_agg(kcu.column_name ORDER BY kcu.ordinal_position) AS columns,
+                   ccu.table_name AS references_table,
+                   array_agg(ccu.column_name ORDER BY kcu.ordinal_position) AS references_columns
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+            JOIN information_schema.constraint_column_usage ccu
+              ON ccu.constraint_name = tc.constraint_name
+             AND ccu.table_schema = tc.table_schema
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_name = ANY(%s)
+              AND tc.table_schema = 'public'
+            GROUP BY tc.table_name, ccu.table_name
+        """
+        with conn.cursor() as cur:
+            cur.execute(fk_query, (table_names,))
+            fk_map: dict[str, list[dict[str, Any]]] = {}
+            for row in cur.fetchall():
+                fk_map.setdefault(row["table_name"], []).append(row)
+
+        # 2d. Indexes
+        idx_query = """\
+            SELECT t.relname AS table_name,
+                   i.relname AS index_name,
+                   array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns,
+                   ix.indisunique AS is_unique
+            FROM pg_class t
+            JOIN pg_class i ON i.oid = ix.indexrelid
+            JOIN pg_index ix ON ix.indexrelid = i.oid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+            WHERE t.relkind IN _IDXRELKIND_PLACEHOLDER
+              AND t.relname = ANY(%s)
+              AND n.nspname = 'public'
+            GROUP BY t.relname, i.relname, ix.indisunique
+        """
+        idx_query = idx_query.replace("_IDXRELKIND_PLACEHOLDER", "('r', 'v', 'm')")
+        with conn.cursor() as cur:
+            cur.execute(idx_query, (table_names,))
+            idx_map: dict[str, list[dict[str, Any]]] = {}
+            for row in cur.fetchall():
+                idx_map.setdefault(row["table_name"], []).append(row)
+
+        # --- 3. Assemble TableInfo objects ---
+        for tname in table_names:
+            columns = [
+                ColumnInfo(
+                    name=r["column_name"],
+                    type=r["data_type"],
+                    nullable=r["is_nullable"] == "YES",
+                    default=r["column_default"],
+                )
+                for r in cols_by_table.get(tname, [])
+            ]
+
+            primary_key = pk_map.get(tname, [])
+
+            foreign_keys = [
+                ForeignKey(
+                    columns=r["columns"],
+                    references_table=r["references_table"],
+                    references_columns=r["references_columns"],
+                )
+                for r in fk_map.get(tname, [])
+            ]
+
+            indexes = [
+                IndexInfo(
+                    name=r["index_name"],
+                    columns=r["columns"],
+                    unique=r["is_unique"],
+                )
+                for r in idx_map.get(tname, [])
+            ]
+
+            # Use a synthetic schema file name: "<table_name>.sql" to mirror
+            # the file parser's per-file structure.
+            schema_file = f"{tname}.sql"
+            table_info = TableInfo(
+                name=tname,
+                schema_file=schema_file,
+                columns=columns,
+                primary_key=primary_key,
+                foreign_keys=foreign_keys,
+                indexes=indexes,
+            )
+
+            tables_by_file.setdefault(schema_file, {})[tname] = table_info
+
+        # Flatten into SchemaIndex.files dict (key = schema_file)
+        for schema_file, tables_dict in tables_by_file.items():
+            index.files[schema_file] = sorted(tables_dict.values(), key=lambda t: t.name)
+
+    debug(f"Introspected {len(index.files)} schema files, {sum(len(t) for t in index.files.values())} tables")
+    return index

--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -78,29 +78,37 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
         if not user_schemas:
             return index
 
-        # --- 1. Collect tables (names + primary keys) ---
+        # --- 1. Collect tables (schema-qualified names) ---
         tables_query = f"""\
-            SELECT c.relname AS table_name
+            SELECT n.nspname AS schema_name,
+                   c.relname AS table_name
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
             LEFT JOIN pg_inherits i ON i.inhrelid = c.oid
             WHERE c.relkind IN {_RELKIND_FILTER}
               AND i.inhrelid IS NULL
               AND n.nspname = ANY(%s)
-            ORDER BY c.relname
+            ORDER BY n.nspname, c.relname
         """
         with conn.cursor() as cur:
             cur.execute(tables_query, (user_schemas,))
-            table_names: list[str] = [row["table_name"] for row in cur.fetchall()]
+            table_ids: list[tuple[str, str]] = [
+                (row["schema_name"], row["table_name"]) for row in cur.fetchall()
+            ]
 
-        if not table_names:
+        if not table_ids:
             return index
+
+        # Extract flat lists for legacy ANY() filters
+        table_names: list[str] = [t for _, t in table_ids]
+        schema_names: list[str] = [s for s, _ in table_ids]
 
         # --- 2. Collect all data in parallel-ish queries (single connection, sequential) ---
 
         # 2a. Primary keys per table
         pk_query = f"""\
-            SELECT c.relname AS table_name,
+            SELECT n.nspname AS schema_name,
+                   c.relname AS table_name,
                    array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS pk_columns
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -108,33 +116,39 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(ix.indkey)
             WHERE c.relname = ANY(%s)
               AND n.nspname = ANY(%s)
-            GROUP BY c.relname
+            GROUP BY n.nspname, c.relname
         """
         with conn.cursor() as cur:
             cur.execute(pk_query, (table_names, user_schemas))
-            pk_map: dict[str, list[str]] = {
-                row["table_name"]: _pg_array_to_list(row["pk_columns"]) for row in cur.fetchall()
+            pk_map: dict[tuple[str, str], list[str]] = {
+                (row["schema_name"], row["table_name"]): _pg_array_to_list(row["pk_columns"])
+                for row in cur.fetchall()
             }
 
         # 2b. Columns per table
         col_query = """\
-            SELECT table_name, column_name, data_type, is_nullable, column_default
+            SELECT table_schema AS schema_name,
+                   table_name, column_name, data_type, is_nullable, column_default
             FROM information_schema.columns
             WHERE table_name = ANY(%s)
               AND table_schema = ANY(%s)
-            ORDER BY table_name, ordinal_position
+            ORDER BY table_schema, table_name, ordinal_position
         """
         with conn.cursor() as cur:
             cur.execute(col_query, (table_names, user_schemas))
-            # Group by table
-            cols_by_table: dict[str, list[dict[str, Any]]] = {}
+            # Group by (schema, table)
+            cols_by_table: dict[tuple[str, str], list[dict[str, Any]]] = {}
             for row in cur.fetchall():
-                cols_by_table.setdefault(row["table_name"], []).append(row)
+                cols_by_table.setdefault(
+                    (row["schema_name"], row["table_name"]), []
+                ).append(row)
 
         # 2c. Foreign keys
         fk_query = """\
-            SELECT tc.table_name,
+            SELECT tc.table_schema AS schema_name,
+                   tc.table_name,
                    array_agg(kcu.column_name ORDER BY kcu.ordinal_position) AS columns,
+                   ccu.table_schema AS references_schema,
                    ccu.table_name AS references_table,
                    array_agg(ccu.column_name ORDER BY kcu.ordinal_position) AS references_columns
             FROM information_schema.table_constraints tc
@@ -147,20 +161,21 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             WHERE tc.constraint_type = 'FOREIGN KEY'
               AND tc.table_name = ANY(%s)
               AND tc.table_schema = ANY(%s)
-            GROUP BY tc.table_name, ccu.table_name
+            GROUP BY tc.table_schema, tc.table_name, ccu.table_schema, ccu.table_name
         """
         with conn.cursor() as cur:
             cur.execute(fk_query, (table_names, user_schemas))
-            fk_map: dict[str, list[dict[str, Any]]] = {}
+            fk_map: dict[tuple[str, str], list[dict[str, Any]]] = {}
             for row in cur.fetchall():
                 r = dict(row)  # Row → mutable dict
                 r["columns"] = _pg_array_to_list(r["columns"])
                 r["references_columns"] = _pg_array_to_list(r["references_columns"])
-                fk_map.setdefault(r["table_name"], []).append(r)
+                fk_map.setdefault((r["schema_name"], r["table_name"]), []).append(r)
 
         # 2d. Indexes
         idx_query = f"""\
-            SELECT t.relname AS table_name,
+            SELECT n.nspname AS schema_name,
+                   t.relname AS table_name,
                    i.relname AS index_name,
                    array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns,
                    ix.indisunique AS is_unique
@@ -174,18 +189,20 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
               AND pi.inhrelid IS NULL
               AND t.relname = ANY(%s)
               AND n.nspname = ANY(%s)
-            GROUP BY t.relname, i.relname, ix.indisunique
+            GROUP BY n.nspname, t.relname, i.relname, ix.indisunique
         """
         with conn.cursor() as cur:
             cur.execute(idx_query, (table_names, user_schemas))
-            idx_map: dict[str, list[dict[str, Any]]] = {}
+            idx_map: dict[tuple[str, str], list[dict[str, Any]]] = {}
             for row in cur.fetchall():
                 r = dict(row)
                 r["columns"] = _pg_array_to_list(r["columns"])
-                idx_map.setdefault(r["table_name"], []).append(r)
+                idx_map.setdefault((r["schema_name"], r["table_name"]), []).append(r)
 
         # --- 3. Assemble TableInfo objects ---
-        for tname in table_names:
+        for schema_name, tname in table_ids:
+            table_id = (schema_name, tname)
+
             columns = [
                 ColumnInfo(
                     name=r["column_name"],
@@ -193,10 +210,10 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
                     nullable=r["is_nullable"] == "YES",
                     default=r["column_default"],
                 )
-                for r in cols_by_table.get(tname, [])
+                for r in cols_by_table.get(table_id, [])
             ]
 
-            primary_key = pk_map.get(tname, [])
+            primary_key = pk_map.get(table_id, [])
 
             foreign_keys = [
                 ForeignKey(
@@ -204,7 +221,7 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
                     references_table=r["references_table"],
                     references_columns=r["references_columns"],
                 )
-                for r in fk_map.get(tname, [])
+                for r in fk_map.get(table_id, [])
             ]
 
             indexes = [
@@ -213,12 +230,13 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
                     columns=r["columns"],
                     unique=r["is_unique"],
                 )
-                for r in idx_map.get(tname, [])
+                for r in idx_map.get(table_id, [])
             ]
 
-            # Use a synthetic schema file name: "<table_name>.sql" to mirror
-            # the file parser's per-file structure.
-            schema_file = f"{tname}.sql"
+            # Schema-qualified file name so tables with the same name in
+            # different schemas (e.g. public.users vs. auth.users) don't
+            # collide or overwrite each other.
+            schema_file = f"{schema_name}.{tname}.sql"
             table_info = TableInfo(
                 name=tname,
                 schema_file=schema_file,

--- a/src/skene/cli/commands/analyse_journey.py
+++ b/src/skene/cli/commands/analyse_journey.py
@@ -22,6 +22,7 @@ from skene.analyzers.journey.pipeline import (
     run_journey_pipeline,
 )
 from skene.analyzers.journey.serialize import write as write_journey
+from skene.analyzers.schema_parsers.models import SchemaIndex
 from skene.cli._journey_runner import (
     build_llm,
     require_llm_credentials,
@@ -30,7 +31,7 @@ from skene.cli._journey_runner import (
     resolve_cli_config,
 )
 from skene.cli.app import app
-from skene.output import console, error
+from skene.output import console, error, status
 from skene.output_paths import DEFAULT_OUTPUT_DIR
 
 
@@ -47,7 +48,17 @@ def analyse_journey_cmd(
     schema_dir: Path | None = typer.Option(
         None,
         "--schema-dir",
-        help=("Directory of pre-exported *.sql files for the schema agent. Required when no codebase path is given."),
+        help=("Directory of pre-exported *.sql files for the schema agent."),
+    ),
+    db_url: str | None = typer.Option(
+        None,
+        "--db-url",
+        envvar="SKENE_DB_URL",
+        help=(
+            "PostgreSQL connection string to introspect for the schema agent, "
+            "as an alternative to --schema-dir. Must be a complete connection "
+            "string. Never stored. Example: postgresql://user:pass@host:5432/db"
+        ),
     ),
     output: Path = typer.Option(
         Path(f"{DEFAULT_OUTPUT_DIR}/journey.yaml"),
@@ -159,10 +170,16 @@ def analyse_journey_cmd(
         skene analyse-journey ./my-app --schema-dir ./supabase-schemas
         skene analyse-journey --schema-dir ./schemas -o journey.json
         skene analyse-journey ./my-app  # code-only mode (no SQL)
+        skene analyse-journey --db-url postgresql://user:pass@host:5432/db
     """
+    # --schema-dir and --db-url are mutually exclusive.
+    if schema_dir is not None and db_url is not None:
+        error("--schema-dir and --db-url are mutually exclusive")
+        raise typer.Exit(2)
+
     # At least one input is required.
-    if path is None and schema_dir is None:
-        error("at least one of PATH or --schema-dir is required")
+    if path is None and schema_dir is None and db_url is None:
+        error("at least one of PATH, --schema-dir, or --db-url is required")
         raise typer.Exit(2)
 
     base_path = resolve_base_path(path) if path is not None else None
@@ -191,11 +208,27 @@ def analyse_journey_cmd(
     journey_path = resolve_artifact_path(output, "journey.yaml")
     journey_path.parent.mkdir(parents=True, exist_ok=True)
 
-    resolved_product_name = product_name or _infer_product_name(base_path, schema_path)
+    # Introspect live DB if --db-url is set.
+    live_schema_index: SchemaIndex | None = None
+    db_display: str | None = None
+    if db_url is not None:
+        from skene.analyzers.schema_parsers.postgres_live import introspect_db
+
+        db_display = _redact_db_url(db_url)
+        status(f"Introspecting database: {db_display}")
+        try:
+            live_schema_index = introspect_db(db_url)
+        except Exception as e:  # noqa: BLE001 — never leak connection details
+            error(f"Failed to introspect database: {e}")
+            raise typer.Exit(1) from e
+        status(f"Introspection complete: {sum(len(t) for t in live_schema_index.files.values())} tables found")
+
+    resolved_product_name = product_name or _infer_product_name(base_path, schema_path, db_url)
 
     cfg = JourneyPipelineConfig(
         repo_root=base_path,
         schema_dir=schema_path,
+        schema_index=live_schema_index,
         product_name=resolved_product_name,
         classify_concurrency=classify_concurrency,
         schema_max_turns=schema_max_turns,
@@ -207,6 +240,7 @@ def analyse_journey_cmd(
         title="skene · analyse-journey",
         base_path=base_path,
         schema_dir=schema_path,
+        db_display=db_display,
         rc=rc,
         product_name=resolved_product_name,
         journey_path=journey_path,
@@ -302,12 +336,61 @@ def _maybe_auto_publish(rc, project_root: Path, *, journey_path: Path, enabled: 
         warning(f"Could not publish journey to Skene Cloud: {result.get('message', 'unknown error')}")
 
 
-def _infer_product_name(repo_root: Path | None, schema_dir: Path | None) -> str:
+def _infer_product_name(
+    repo_root: Path | None,
+    schema_dir: Path | None,
+    db_url: str | None = None,
+) -> str:
     if repo_root is not None:
         return repo_root.name or "Product"
+    if db_url is not None:
+        # Extract database name from DSN: postgresql://user:pass@host:port/dbname
+        try:
+            # Remove scheme
+            rest = db_url.split("://", 1)[-1]
+            # Skip credentials (user:pass@)
+            if "@" in rest:
+                rest = rest.split("@")[-1]
+            # After host:port/, the next segment is the database name
+            path_part = rest.split("/", 1)
+            if len(path_part) > 1 and path_part[1]:
+                return path_part[1].split("?")[0].split("&")[0] or "Product"
+        except Exception:  # noqa: BLE001
+            pass
+        return "Product"
     if schema_dir is not None:
-        return schema_dir.parent.name or schema_dir.name or "Product"
+        return schema_dir.name or "Product"
     return "Product"
+
+
+def _redact_db_url(url: str) -> str:
+    """Return a display-safe version of a DB URL with password redacted.
+
+    Examples::
+
+        postgresql://user:secret@host:5432/mydb  →  postgresql://user:***@host:5432/mydb
+        postgresql://user@host/mydb              →  postgresql://user@host/mydb
+    """
+    try:
+        if "://" not in url:
+            return "<redacted>"
+
+        scheme, rest = url.split("://", 1)
+
+        if "@" in rest:
+            creds, remainder = rest.split("@", 1)
+            if ":" in creds and not creds.endswith(":"):
+                # Has a password — redact it
+                user = creds.split(":", 1)[0]
+                rest = f"{user}:***@{remainder}"
+            else:
+                rest = f"{creds}@{remainder}"
+        else:
+            rest = rest
+
+        return f"{scheme}://{rest}"
+    except Exception:  # noqa: BLE001
+        return "<redacted>"
 
 
 def _render_kickoff(
@@ -315,15 +398,24 @@ def _render_kickoff(
     title: str,
     base_path: Path | None,
     schema_dir: Path | None,
+    db_display: str | None,
     rc,
     product_name: str,
     journey_path: Path,
     specialize: bool,
 ) -> None:
+    # Build schema display: DB URL takes precedence, then schema_dir.
+    if db_display is not None:
+        schema_display = f"[dim]{db_display}[/dim]"
+    elif schema_dir is not None:
+        schema_display = str(schema_dir)
+    else:
+        schema_display = "[dim](none)[/dim]"
+
     lines = [
         f"[bold]Product[/bold]    {product_name}",
         f"[bold]Repo[/bold]       {base_path or '[dim](none)[/dim]'}",
-        f"[bold]Schema[/bold]     {schema_dir or '[dim](none)[/dim]'}",
+        f"[bold]Schema[/bold]     {schema_display}",
         f"[bold]Output[/bold]     {journey_path}",
         f"[bold]Provider[/bold]   {rc.provider} · [dim]{rc.model}[/dim]",
         f"[bold]Specialize[/bold] {'yes' if specialize else 'no'}",

--- a/tests/test_cli/test_analyse_journey_db_url.py
+++ b/tests/test_cli/test_analyse_journey_db_url.py
@@ -1,0 +1,95 @@
+"""Tests for analyse-journey CLI helpers and --db-url integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skene.analyzers.journey.pipeline import JourneyPipelineConfig
+from skene.analyzers.schema_parsers.models import SchemaIndex
+from skene.cli.commands.analyse_journey import _infer_product_name, _redact_db_url
+
+
+class TestRedactDbUrl:
+    """Test _redact_db_url password redaction."""
+
+    def test_redacts_password(self):
+        assert _redact_db_url("postgresql://user:secret@host:5432/mydb") == "postgresql://user:***@host:5432/mydb"
+
+    def test_no_password_keeps_user(self):
+        assert _redact_db_url("postgresql://user@host/mydb") == "postgresql://user@host/mydb"
+
+    def test_preserves_scheme(self):
+        assert _redact_db_url("postgresql+async://user:pass@host/db") == "postgresql+async://user:***@host/db"
+
+    def test_handles_no_at_sign(self):
+        # No credentials at all
+        assert _redact_db_url("postgresql://host/db") == "postgresql://host/db"
+
+    def test_handles_query_params(self):
+        assert (
+            _redact_db_url("postgresql://user:pass@host/db?sslmode=require")
+            == "postgresql://user:***@host/db?sslmode=require"
+        )
+
+    def test_corrupt_url_returns_redacted(self):
+        assert _redact_db_url("not-a-valid-url-at-all") == "<redacted>"
+
+
+class TestInferProductName:
+    """Test _infer_product_name heuristics."""
+
+    def test_from_repo_root(self):
+        assert _infer_product_name(Path("/home/user/my-app"), None) == "my-app"
+
+    def test_from_schema_dir(self):
+        assert _infer_product_name(None, Path("/data/schemas")) == "schemas"
+
+    def test_from_db_url(self):
+        assert _infer_product_name(None, None, "postgresql://user:pass@host/mydb") == "mydb"
+
+    def test_from_db_url_no_path(self):
+        assert _infer_product_name(None, None, "postgresql://user:pass@host") == "Product"
+
+    def test_repo_takes_precedence_over_db(self):
+        assert _infer_product_name(Path("/home/user/app"), None, "postgresql://host/db") == "app"
+
+    def test_fallback_to_product(self):
+        assert _infer_product_name(None, None, None) == "Product"
+
+
+class TestJourneyPipelineConfigWithSchemaIndex:
+    """Test JourneyPipelineConfig accepts schema_index."""
+
+    def test_config_with_schema_index(self):
+        index = SchemaIndex()
+        cfg = JourneyPipelineConfig(
+            repo_root=None,
+            schema_dir=None,
+            schema_index=index,
+            product_name="Test",
+        )
+        assert cfg.schema_index is index
+        assert cfg.schema_dir is None
+
+    def test_config_rejects_schema_dir_and_schema_index(self):
+        index = SchemaIndex()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            JourneyPipelineConfig(
+                repo_root=None,
+                schema_dir=Path("/tmp/schemas"),
+                schema_index=index,
+                product_name="Test",
+            )
+
+    def test_config_with_repo_and_schema_index(self):
+        index = SchemaIndex()
+        cfg = JourneyPipelineConfig(
+            repo_root=Path("/tmp/repo"),
+            schema_dir=None,
+            schema_index=index,
+            product_name="Test",
+        )
+        assert cfg.repo_root is not None
+        assert cfg.schema_index is index

--- a/tests/test_journey/test_schema_tools.py
+++ b/tests/test_journey/test_schema_tools.py
@@ -205,7 +205,7 @@ async def test_run_schema_agent_against_fixture():
             return AssistantTurn(text="done")
 
     client = _ScriptedAgent()
-    candidates = await run_schema_agent(fixture, client, max_turns=10)
+    candidates = await run_schema_agent(fixture, llm=client, max_turns=10)
     assert len(candidates) == 1
     assert candidates[0].proposed_id == "account_created"
     assert candidates[0].evidence[0].source.value == "db"

--- a/tests/test_schema_parsers/__init__.py
+++ b/tests/test_schema_parsers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for schema parser package."""

--- a/tests/test_schema_parsers/test_postgres_live.py
+++ b/tests/test_schema_parsers/test_postgres_live.py
@@ -14,6 +14,7 @@ from skene.analyzers.schema_parsers.postgres_live import introspect_db
 
 
 def _build_mock_conn(
+    schemas: list[str],
     tables: list[str],
     pk_rows: list[dict],
     col_rows: list[dict],
@@ -25,6 +26,14 @@ def _build_mock_conn(
     psycopg.connect() returns a connection that acts as a context manager,
     so the mock must support __enter__/__exit__ and cursor() must return
     cursors that are also context managers.
+
+    Cursor call order:
+    1. Schema discovery (_discover_user_schemas)
+    2. Tables query
+    3. Primary keys query
+    4. Columns query
+    5. Foreign keys query
+    6. Indexes query
     """
 
     def _make_cursor(rows: list[dict]) -> MagicMock:
@@ -35,11 +44,12 @@ def _build_mock_conn(
         return cur
 
     cursors = [
-        _make_cursor([{"table_name": t} for t in tables]),
-        _make_cursor(pk_rows),
-        _make_cursor(col_rows),
-        _make_cursor(fk_rows),
-        _make_cursor(idx_rows),
+        _make_cursor([{"nspname": s} for s in schemas]),  # schema discovery
+        _make_cursor([{"table_name": t} for t in tables]),  # tables
+        _make_cursor(pk_rows),  # primary keys
+        _make_cursor(col_rows),  # columns
+        _make_cursor(fk_rows),  # foreign keys
+        _make_cursor(idx_rows),  # indexes
     ]
     conn = MagicMock()
     conn.__enter__ = lambda s: conn
@@ -53,7 +63,14 @@ class TestIntrospectDb:
 
     def test_empty_db_returns_empty_index(self):
         """An empty database returns a SchemaIndex with no files."""
-        mock_conn = _build_mock_conn(tables=[], pk_rows=[], col_rows=[], fk_rows=[], idx_rows=[])
+        mock_conn = _build_mock_conn(
+            schemas=["public"],
+            tables=[],
+            pk_rows=[],
+            col_rows=[],
+            fk_rows=[],
+            idx_rows=[],
+        )
         with patch("psycopg.connect", return_value=mock_conn):
             index = introspect_db("postgresql://user:pass@localhost/db")
         assert index.files == {}
@@ -61,6 +78,7 @@ class TestIntrospectDb:
     def test_single_table_basic(self):
         """A single table with columns, PK, FK, and index."""
         mock_conn = _build_mock_conn(
+            schemas=["public"],
             tables=["users"],
             pk_rows=[{"table_name": "users", "pk_columns": ["id"]}],
             col_rows=[
@@ -122,6 +140,7 @@ class TestIntrospectDb:
     def test_table_with_foreign_keys(self):
         """Tables with FK relationships are captured."""
         mock_conn = _build_mock_conn(
+            schemas=["public"],
             tables=["orders", "users"],
             pk_rows=[
                 {"table_name": "orders", "pk_columns": ["id"]},
@@ -190,6 +209,7 @@ class TestIntrospectDb:
     def test_views_included(self):
         """Views are included in the schema index."""
         mock_conn = _build_mock_conn(
+            schemas=["public"],
             tables=["user_summary"],
             pk_rows=[],
             col_rows=[
@@ -259,6 +279,7 @@ class TestIntrospectDb:
     def test_multiple_tables_different_files(self):
         """Each table gets its own schema file entry."""
         mock_conn = _build_mock_conn(
+            schemas=["public"],
             tables=["users", "posts"],
             pk_rows=[
                 {"table_name": "users", "pk_columns": ["id"]},
@@ -290,3 +311,63 @@ class TestIntrospectDb:
         file_keys = sorted(index.files.keys())
         assert "posts.sql" in file_keys
         assert "users.sql" in file_keys
+
+
+class TestSchemaDiscovery:
+    """Test that system/extension schemas are excluded from introspection."""
+
+    def test_system_schemas_excluded(self):
+        """pg_catalog, information_schema, and pg_toast are not returned as user schemas."""
+        # The mock returns only 'public' and 'app' as user schemas;
+        # pg_catalog, information_schema, and a fake extension schema
+        # are implicitly excluded by the _discover_user_schemas query.
+        mock_conn = _build_mock_conn(
+            schemas=["public", "app"],  # only user schemas returned
+            tables=["users"],
+            pk_rows=[{"table_name": "users", "pk_columns": ["id"]}],
+            col_rows=[
+                {
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[],
+            idx_rows=[],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        # Should find the table in public schema
+        assert len(index.files) == 1
+        tables = list(index.files.values())[0]
+        assert len(tables) == 1
+        assert tables[0].name == "users"
+
+    def test_custom_schema_tables_included(self):
+        """Tables in non-public user schemas are included."""
+        mock_conn = _build_mock_conn(
+            schemas=["public", "tenant_a"],
+            tables=["customers"],
+            pk_rows=[{"table_name": "customers", "pk_columns": ["id"]}],
+            col_rows=[
+                {
+                    "table_name": "customers",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[],
+            idx_rows=[],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        assert len(index.files) == 1
+        tables = list(index.files.values())[0]
+        assert len(tables) == 1
+        assert tables[0].name == "customers"

--- a/tests/test_schema_parsers/test_postgres_live.py
+++ b/tests/test_schema_parsers/test_postgres_live.py
@@ -1,0 +1,292 @@
+"""Tests for skene.analyzers.schema_parsers.postgres_live."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skene.analyzers.schema_parsers.models import (
+    ForeignKey,
+    TableInfo,
+)
+from skene.analyzers.schema_parsers.postgres_live import introspect_db
+
+
+def _build_mock_conn(
+    tables: list[str],
+    pk_rows: list[dict],
+    col_rows: list[dict],
+    fk_rows: list[dict],
+    idx_rows: list[dict],
+) -> MagicMock:
+    """Build a fully wired mock psycopg connection.
+
+    psycopg.connect() returns a connection that acts as a context manager,
+    so the mock must support __enter__/__exit__ and cursor() must return
+    cursors that are also context managers.
+    """
+
+    def _make_cursor(rows: list[dict]) -> MagicMock:
+        cur = MagicMock()
+        cur.__enter__ = lambda s: cur
+        cur.__exit__ = lambda s, *a: None
+        cur.fetchall.return_value = rows
+        return cur
+
+    cursors = [
+        _make_cursor([{"table_name": t} for t in tables]),
+        _make_cursor(pk_rows),
+        _make_cursor(col_rows),
+        _make_cursor(fk_rows),
+        _make_cursor(idx_rows),
+    ]
+    conn = MagicMock()
+    conn.__enter__ = lambda s: conn
+    conn.__exit__ = lambda s, *a: None
+    conn.cursor.side_effect = cursors
+    return conn
+
+
+class TestIntrospectDb:
+    """Test introspect_db produces correct SchemaIndex."""
+
+    def test_empty_db_returns_empty_index(self):
+        """An empty database returns a SchemaIndex with no files."""
+        mock_conn = _build_mock_conn(tables=[], pk_rows=[], col_rows=[], fk_rows=[], idx_rows=[])
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+        assert index.files == {}
+
+    def test_single_table_basic(self):
+        """A single table with columns, PK, FK, and index."""
+        mock_conn = _build_mock_conn(
+            tables=["users"],
+            pk_rows=[{"table_name": "users", "pk_columns": ["id"]}],
+            col_rows=[
+                {
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "table_name": "users",
+                    "column_name": "email",
+                    "data_type": "text",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "table_name": "users",
+                    "column_name": "name",
+                    "data_type": "text",
+                    "is_nullable": "YES",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[],
+            idx_rows=[
+                {
+                    "table_name": "users",
+                    "index_name": "users_pkey",
+                    "columns": ["id"],
+                    "is_unique": True,
+                },
+            ],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        assert len(index.files) == 1
+        tables = list(index.files.values())[0]
+        assert len(tables) == 1
+        t = tables[0]
+        assert isinstance(t, TableInfo)
+        assert t.name == "users"
+        assert len(t.columns) == 3
+        assert t.columns[0].name == "id"
+        assert t.columns[0].type == "uuid"
+        assert t.columns[0].nullable is False
+        assert t.columns[1].name == "email"
+        assert t.columns[1].nullable is False
+        assert t.columns[2].name == "name"
+        assert t.columns[2].nullable is True
+        assert t.primary_key == ["id"]
+        assert len(t.foreign_keys) == 0
+        assert len(t.indexes) == 1
+        assert t.indexes[0].name == "users_pkey"
+        assert t.indexes[0].unique is True
+
+    def test_table_with_foreign_keys(self):
+        """Tables with FK relationships are captured."""
+        mock_conn = _build_mock_conn(
+            tables=["orders", "users"],
+            pk_rows=[
+                {"table_name": "orders", "pk_columns": ["id"]},
+                {"table_name": "users", "pk_columns": ["id"]},
+            ],
+            col_rows=[
+                {
+                    "table_name": "orders",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "table_name": "orders",
+                    "column_name": "user_id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[
+                {
+                    "table_name": "orders",
+                    "columns": ["user_id"],
+                    "references_table": "users",
+                    "references_columns": ["id"],
+                },
+            ],
+            idx_rows=[
+                {
+                    "table_name": "orders",
+                    "index_name": "orders_pkey",
+                    "columns": ["id"],
+                    "is_unique": True,
+                },
+                {
+                    "table_name": "users",
+                    "index_name": "users_pkey",
+                    "columns": ["id"],
+                    "is_unique": True,
+                },
+            ],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        assert len(index.files) == 2
+        for tables in index.files.values():
+            for t in tables:
+                if t.name == "orders":
+                    assert len(t.foreign_keys) == 1
+                    fk = t.foreign_keys[0]
+                    assert isinstance(fk, ForeignKey)
+                    assert fk.columns == ["user_id"]
+                    assert fk.references_table == "users"
+                    assert fk.references_columns == ["id"]
+
+    def test_views_included(self):
+        """Views are included in the schema index."""
+        mock_conn = _build_mock_conn(
+            tables=["user_summary"],
+            pk_rows=[],
+            col_rows=[
+                {
+                    "table_name": "user_summary",
+                    "column_name": "user_id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "table_name": "user_summary",
+                    "column_name": "total_orders",
+                    "data_type": "integer",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[],
+            idx_rows=[],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        assert len(index.files) == 1
+        for tables in index.files.values():
+            assert len(tables) == 1
+            assert tables[0].name == "user_summary"
+
+    def test_connection_error_propagates(self):
+        """Connection errors are not swallowed."""
+        import psycopg
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.side_effect = psycopg.OperationalError("connection refused")
+        mock_cursor.__enter__ = lambda s: mock_cursor
+        mock_cursor.__exit__ = lambda s, *a: None
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = lambda s, *a: None
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            with pytest.raises(psycopg.OperationalError, match="connection refused"):
+                introspect_db("postgresql://user:badpass@localhost/nonexistent")
+
+    def test_password_not_in_exception(self):
+        """Password is not leaked in exception messages."""
+        import psycopg
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.side_effect = psycopg.OperationalError("password authentication failed")
+        mock_cursor.__enter__ = lambda s: mock_cursor
+        mock_cursor.__exit__ = lambda s, *a: None
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = lambda s, *a: None
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            with pytest.raises(psycopg.OperationalError) as exc_info:
+                introspect_db("postgresql://testuser:supersecret@localhost/testdb")
+        assert "supersecret" not in str(exc_info.value)
+
+    def test_multiple_tables_different_files(self):
+        """Each table gets its own schema file entry."""
+        mock_conn = _build_mock_conn(
+            tables=["users", "posts"],
+            pk_rows=[
+                {"table_name": "users", "pk_columns": ["id"]},
+                {"table_name": "posts", "pk_columns": ["id"]},
+            ],
+            col_rows=[
+                {
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "table_name": "posts",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[],
+            idx_rows=[],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        assert len(index.files) == 2
+        file_keys = sorted(index.files.keys())
+        assert "posts.sql" in file_keys
+        assert "users.sql" in file_keys

--- a/tests/test_schema_parsers/test_postgres_live.py
+++ b/tests/test_schema_parsers/test_postgres_live.py
@@ -15,7 +15,7 @@ from skene.analyzers.schema_parsers.postgres_live import introspect_db
 
 def _build_mock_conn(
     schemas: list[str],
-    tables: list[str],
+    tables: list[tuple[str, str]],
     pk_rows: list[dict],
     col_rows: list[dict],
     fk_rows: list[dict],
@@ -26,6 +26,8 @@ def _build_mock_conn(
     psycopg.connect() returns a connection that acts as a context manager,
     so the mock must support __enter__/__exit__ and cursor() must return
     cursors that are also context managers.
+
+    *tables* is a list of ``(schema_name, table_name)`` tuples.
 
     Cursor call order:
     1. Schema discovery (_discover_user_schemas)
@@ -45,7 +47,9 @@ def _build_mock_conn(
 
     cursors = [
         _make_cursor([{"nspname": s} for s in schemas]),  # schema discovery
-        _make_cursor([{"table_name": t} for t in tables]),  # tables
+        _make_cursor(
+            [{"schema_name": s, "table_name": t} for s, t in tables]
+        ),  # tables
         _make_cursor(pk_rows),  # primary keys
         _make_cursor(col_rows),  # columns
         _make_cursor(fk_rows),  # foreign keys
@@ -79,10 +83,11 @@ class TestIntrospectDb:
         """A single table with columns, PK, FK, and index."""
         mock_conn = _build_mock_conn(
             schemas=["public"],
-            tables=["users"],
-            pk_rows=[{"table_name": "users", "pk_columns": ["id"]}],
+            tables=[("public", "users")],
+            pk_rows=[{"schema_name": "public", "table_name": "users", "pk_columns": ["id"]}],
             col_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -90,6 +95,7 @@ class TestIntrospectDb:
                     "column_default": None,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "column_name": "email",
                     "data_type": "text",
@@ -97,6 +103,7 @@ class TestIntrospectDb:
                     "column_default": None,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "column_name": "name",
                     "data_type": "text",
@@ -107,6 +114,7 @@ class TestIntrospectDb:
             fk_rows=[],
             idx_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "index_name": "users_pkey",
                     "columns": ["id"],
@@ -118,7 +126,8 @@ class TestIntrospectDb:
             index = introspect_db("postgresql://user:pass@localhost/db")
 
         assert len(index.files) == 1
-        tables = list(index.files.values())[0]
+        assert "public.users.sql" in index.files
+        tables = index.files["public.users.sql"]
         assert len(tables) == 1
         t = tables[0]
         assert isinstance(t, TableInfo)
@@ -141,13 +150,14 @@ class TestIntrospectDb:
         """Tables with FK relationships are captured."""
         mock_conn = _build_mock_conn(
             schemas=["public"],
-            tables=["orders", "users"],
+            tables=[("public", "orders"), ("public", "users")],
             pk_rows=[
-                {"table_name": "orders", "pk_columns": ["id"]},
-                {"table_name": "users", "pk_columns": ["id"]},
+                {"schema_name": "public", "table_name": "orders", "pk_columns": ["id"]},
+                {"schema_name": "public", "table_name": "users", "pk_columns": ["id"]},
             ],
             col_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "orders",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -155,6 +165,7 @@ class TestIntrospectDb:
                     "column_default": None,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "orders",
                     "column_name": "user_id",
                     "data_type": "uuid",
@@ -162,6 +173,7 @@ class TestIntrospectDb:
                     "column_default": None,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -171,20 +183,24 @@ class TestIntrospectDb:
             ],
             fk_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "orders",
                     "columns": ["user_id"],
+                    "references_schema": "public",
                     "references_table": "users",
                     "references_columns": ["id"],
                 },
             ],
             idx_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "orders",
                     "index_name": "orders_pkey",
                     "columns": ["id"],
                     "is_unique": True,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "index_name": "users_pkey",
                     "columns": ["id"],
@@ -196,24 +212,25 @@ class TestIntrospectDb:
             index = introspect_db("postgresql://user:pass@localhost/db")
 
         assert len(index.files) == 2
-        for tables in index.files.values():
-            for t in tables:
-                if t.name == "orders":
-                    assert len(t.foreign_keys) == 1
-                    fk = t.foreign_keys[0]
-                    assert isinstance(fk, ForeignKey)
-                    assert fk.columns == ["user_id"]
-                    assert fk.references_table == "users"
-                    assert fk.references_columns == ["id"]
+        orders_tables = index.files["public.orders.sql"]
+        for t in orders_tables:
+            if t.name == "orders":
+                assert len(t.foreign_keys) == 1
+                fk = t.foreign_keys[0]
+                assert isinstance(fk, ForeignKey)
+                assert fk.columns == ["user_id"]
+                assert fk.references_table == "users"
+                assert fk.references_columns == ["id"]
 
     def test_views_included(self):
         """Views are included in the schema index."""
         mock_conn = _build_mock_conn(
             schemas=["public"],
-            tables=["user_summary"],
+            tables=[("public", "user_summary")],
             pk_rows=[],
             col_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "user_summary",
                     "column_name": "user_id",
                     "data_type": "uuid",
@@ -221,6 +238,7 @@ class TestIntrospectDb:
                     "column_default": None,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "user_summary",
                     "column_name": "total_orders",
                     "data_type": "integer",
@@ -235,9 +253,10 @@ class TestIntrospectDb:
             index = introspect_db("postgresql://user:pass@localhost/db")
 
         assert len(index.files) == 1
-        for tables in index.files.values():
-            assert len(tables) == 1
-            assert tables[0].name == "user_summary"
+        assert "public.user_summary.sql" in index.files
+        tables = index.files["public.user_summary.sql"]
+        assert len(tables) == 1
+        assert tables[0].name == "user_summary"
 
     def test_connection_error_propagates(self):
         """Connection errors are not swallowed."""
@@ -280,13 +299,14 @@ class TestIntrospectDb:
         """Each table gets its own schema file entry."""
         mock_conn = _build_mock_conn(
             schemas=["public"],
-            tables=["users", "posts"],
+            tables=[("public", "users"), ("public", "posts")],
             pk_rows=[
-                {"table_name": "users", "pk_columns": ["id"]},
-                {"table_name": "posts", "pk_columns": ["id"]},
+                {"schema_name": "public", "table_name": "users", "pk_columns": ["id"]},
+                {"schema_name": "public", "table_name": "posts", "pk_columns": ["id"]},
             ],
             col_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -294,6 +314,7 @@ class TestIntrospectDb:
                     "column_default": None,
                 },
                 {
+                    "schema_name": "public",
                     "table_name": "posts",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -309,8 +330,8 @@ class TestIntrospectDb:
 
         assert len(index.files) == 2
         file_keys = sorted(index.files.keys())
-        assert "posts.sql" in file_keys
-        assert "users.sql" in file_keys
+        assert "public.posts.sql" in file_keys
+        assert "public.users.sql" in file_keys
 
 
 class TestSchemaDiscovery:
@@ -323,10 +344,11 @@ class TestSchemaDiscovery:
         # are implicitly excluded by the _discover_user_schemas query.
         mock_conn = _build_mock_conn(
             schemas=["public", "app"],  # only user schemas returned
-            tables=["users"],
-            pk_rows=[{"table_name": "users", "pk_columns": ["id"]}],
+            tables=[("public", "users")],
+            pk_rows=[{"schema_name": "public", "table_name": "users", "pk_columns": ["id"]}],
             col_rows=[
                 {
+                    "schema_name": "public",
                     "table_name": "users",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -342,7 +364,8 @@ class TestSchemaDiscovery:
 
         # Should find the table in public schema
         assert len(index.files) == 1
-        tables = list(index.files.values())[0]
+        assert "public.users.sql" in index.files
+        tables = index.files["public.users.sql"]
         assert len(tables) == 1
         assert tables[0].name == "users"
 
@@ -350,10 +373,11 @@ class TestSchemaDiscovery:
         """Tables in non-public user schemas are included."""
         mock_conn = _build_mock_conn(
             schemas=["public", "tenant_a"],
-            tables=["customers"],
-            pk_rows=[{"table_name": "customers", "pk_columns": ["id"]}],
+            tables=[("tenant_a", "customers")],
+            pk_rows=[{"schema_name": "tenant_a", "table_name": "customers", "pk_columns": ["id"]}],
             col_rows=[
                 {
+                    "schema_name": "tenant_a",
                     "table_name": "customers",
                     "column_name": "id",
                     "data_type": "uuid",
@@ -368,6 +392,112 @@ class TestSchemaDiscovery:
             index = introspect_db("postgresql://user:pass@localhost/db")
 
         assert len(index.files) == 1
-        tables = list(index.files.values())[0]
+        assert "tenant_a.customers.sql" in index.files
+        tables = index.files["tenant_a.customers.sql"]
         assert len(tables) == 1
         assert tables[0].name == "customers"
+
+
+class TestMultiSchema:
+    """Test that same-named tables in different schemas stay distinct."""
+
+    def test_same_table_name_different_schemas(self):
+        """public.users and auth.users produce separate files, no collision."""
+        mock_conn = _build_mock_conn(
+            schemas=["public", "auth"],
+            tables=[("public", "users"), ("auth", "users")],
+            pk_rows=[
+                {"schema_name": "public", "table_name": "users", "pk_columns": ["id"]},
+                {"schema_name": "auth", "table_name": "users", "pk_columns": ["id"]},
+            ],
+            col_rows=[
+                {
+                    "schema_name": "public",
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "public",
+                    "table_name": "users",
+                    "column_name": "email",
+                    "data_type": "text",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "auth",
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "auth",
+                    "table_name": "users",
+                    "column_name": "email",
+                    "data_type": "text",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "auth",
+                    "table_name": "users",
+                    "column_name": "encrypted_password",
+                    "data_type": "text",
+                    "is_nullable": "YES",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[],
+            idx_rows=[
+                {
+                    "schema_name": "public",
+                    "table_name": "users",
+                    "index_name": "users_pkey",
+                    "columns": ["id"],
+                    "is_unique": True,
+                },
+                {
+                    "schema_name": "auth",
+                    "table_name": "users",
+                    "index_name": "users_pkey",
+                    "columns": ["id"],
+                    "is_unique": True,
+                },
+            ],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        # Two separate files, no collision
+        assert len(index.files) == 2
+        assert "public.users.sql" in index.files
+        assert "auth.users.sql" in index.files
+
+        # public.users has 2 columns (id, email)
+        pub_tables = index.files["public.users.sql"]
+        assert len(pub_tables) == 1
+        pub_user = pub_tables[0]
+        assert pub_user.name == "users"
+        assert len(pub_user.columns) == 2
+        assert {c.name for c in pub_user.columns} == {"id", "email"}
+
+        # auth.users has 3 columns (id, email, encrypted_password)
+        auth_tables = index.files["auth.users.sql"]
+        assert len(auth_tables) == 1
+        auth_user = auth_tables[0]
+        assert auth_user.name == "users"
+        assert len(auth_user.columns) == 3
+        assert {c.name for c in auth_user.columns} == {
+            "id",
+            "email",
+            "encrypted_password",
+        }
+
+        # Both have the same index name but in different files
+        assert pub_user.indexes[0].name == "users_pkey"
+        assert auth_user.indexes[0].name == "users_pkey"

--- a/tests/test_schema_parsers/test_postgres_live.py
+++ b/tests/test_schema_parsers/test_postgres_live.py
@@ -501,3 +501,72 @@ class TestMultiSchema:
         # Both have the same index name but in different files
         assert pub_user.indexes[0].name == "users_pkey"
         assert auth_user.indexes[0].name == "users_pkey"
+
+    def test_cross_schema_foreign_key(self):
+        """app.orders.user_id → public.users.id is captured, not dropped."""
+        mock_conn = _build_mock_conn(
+            schemas=["app", "public"],
+            tables=[("app", "orders"), ("public", "users")],
+            pk_rows=[
+                {"schema_name": "app", "table_name": "orders", "pk_columns": ["id"]},
+                {"schema_name": "public", "table_name": "users", "pk_columns": ["id"]},
+            ],
+            col_rows=[
+                {
+                    "schema_name": "app",
+                    "table_name": "orders",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "app",
+                    "table_name": "orders",
+                    "column_name": "user_id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "public",
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[
+                {
+                    "schema_name": "app",
+                    "table_name": "orders",
+                    "columns": ["user_id"],
+                    "references_schema": "public",
+                    "references_table": "users",
+                    "references_columns": ["id"],
+                },
+            ],
+            idx_rows=[
+                {
+                    "schema_name": "app",
+                    "table_name": "orders",
+                    "index_name": "orders_pkey",
+                    "columns": ["id"],
+                    "is_unique": True,
+                },
+            ],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        assert len(index.files) == 2
+        assert "app.orders.sql" in index.files
+        assert "public.users.sql" in index.files
+
+        orders = index.files["app.orders.sql"][0]
+        assert len(orders.foreign_keys) == 1
+        fk = orders.foreign_keys[0]
+        assert fk.columns == ["user_id"]
+        assert fk.references_table == "users"
+        assert fk.references_columns == ["id"]

--- a/uv.lock
+++ b/uv.lock
@@ -649,6 +649,75 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -983,6 +1052,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "loguru" },
     { name = "openai" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -1015,6 +1085,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "openai", specifier = ">=1.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "questionary", marker = "extra == 'ui'", specifier = ">=2.0" },
@@ -1174,6 +1245,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add live PostgreSQL database schema introspection to skene's journey analysis pipeline, replacing the previous file-based SQL parser approach with real-time database discovery via psycopg3.

## Changes
New file: src/skene/analyzers/schema_parsers/postgres_live.py

- Connects to a live PostgreSQL database and introspects its schema using psycopg3
- Discovers user schemas (excluding pg_catalog, information_schema, pg_toast)
- Queries pg_class, pg_index, pg_inherits, and information_schema to extract tables, columns, primary keys, foreign keys, and indexes
- Filters out partition child tables — only includes parent partitioned tables and regular tables
- Converts PostgreSQL array types to Python lists for columns, foreign keys, and indexes
- Returns a SchemaIndex compatible with the existing schema agent tools

 ## Modified files:
- src/skene/analyzers/journey/pipeline_config.py — wires SchemaIndex into pipeline config and schema agent
- src/skene/cli.py — adds --db-url CLI option with validation and connection helpers
- pyproject.toml — adds psycopg[binary] dependency
- docs/ — documents the --db-url feature

## Fixes:
- Index query JOIN order (pg_index referenced before being joined)
- PostgreSQL array string conversion ('{col1,col2}' → ['col1', 'col2'])
- Partition child table filtering via pg_inherits left join

 ## Testing
- Tests added or updated for any behavioral change
- Tests with `uv run --env-file .env skene analyse-journey --db-url "postgresql://postgres:ku23jr71@192.168.0.126:5432/postgres"` with a local and remote database

## Checklist
- [x] PR is focused on a single change (no unrelated refactoring or cleanup)
- [x] Tests added or updated for any behavioral change
- [x] Documentation updated (if behavior, flags, config, or APIs changed)
- [x] Cursor plugin updated (if commands, skills, or core CLI behavior changed)
- [x] Linting and tests pass locally
- [x] No merge conflicts
