### PR TITLE
Backend server phase 1: wire-model schema package + streaming agent loop

### DIFF
--- a/docs/design/backend-server.md
+++ b/docs/design/backend-server.md
@@ -1,0 +1,310 @@
+# Skene Backend Server — Design
+
+Status: draft (2026-07-06)
+
+Goal: turn skene into a client/server system where a **main skene agent** orchestrates
+**code/db subagents** (and future ones), and CLI + TUI are thin clients of a single
+backend service. Architecture is modeled on opencode
+(`/Users/miche/skene/projects/opencode`), adapted to skene's Python engine.
+
+---
+
+## 1. Core decision: copy opencode's architecture, not its code
+
+opencode's current codebase is a TypeScript/Bun monorepo built on the Effect runtime,
+with event-sourced SQLite persistence. Skene's entire engine — agents, `agent_loop`,
+toolsets, tree-sitter/sqlglot analyzers, psycopg introspection, the LLM provider
+layer — is pure async Python and already cleanly separated from the CLI.
+
+**Recommendation:** build the server in Python (FastAPI) around the existing engine,
+and port opencode's *design*: the API shape, the session/message/part model, the SSE
+event bus, the task-tool subagent pattern, the schema-first → OpenAPI → generated
+client flow, and the permission-ask flow.
+
+Why not reuse opencode's code directly:
+
+- Its `core` package is inseparable from the Effect runtime and its custom `LayerNode`
+  DI graph — adopting it means adopting Effect wholesale and rewriting skene's
+  analyzers in TypeScript (tree-sitter, sqlglot, psycopg all have TS analogues, but
+  it's a full engine port for zero product gain).
+- What makes opencode valuable to us is transferable without the runtime: wire shapes
+  (`packages/schema/src/session-message.ts`), route surface
+  (`packages/opencode/src/server/routes/instance/httpapi/groups/session.ts`), the task
+  tool (`packages/opencode/src/tool/task.ts`), the SSE event handler
+  (`.../handlers/event.ts`), and the SDK generation pipeline
+  (`packages/sdk/js/script/build.ts`).
+
+The escape hatch stays open: if skene later converges on opencode's product shape
+(general coding agent, plugins, MCP, 25 providers), the API contract designed here is
+close enough to opencode's that a TS rewrite could slot in under the same clients.
+
+### What we take vs. skip
+
+| opencode piece | Verdict | Notes |
+|---|---|---|
+| Schema-first contract → OpenAPI → generated clients | **Take** | FastAPI gives OpenAPI natively; `oapi-codegen` for the Go TUI client |
+| Sessions/messages/tagged-union parts with streaming `ToolState` | **Take** | Copy shapes from `packages/schema/src/session-message.ts` |
+| SSE `/event` bus with heartbeat + directory filtering | **Take** | Copy semantics from `handlers/event.ts` |
+| Subagents = child sessions spawned by a `task` tool | **Take** | This *is* requirement #1 |
+| Permission `ask` flow (tool pauses, client answers via HTTP) | **Take** (phase 2) | Needed for db-write tools later |
+| Per-request workspace routing (`x-opencode-directory` header) | **Take** | One server, many projects |
+| `serve` / `run` / `attach` CLI lifecycle | **Take** | Same three verbs |
+| SQLite persistence | **Take, simplified** | Plain relational state + event feed, not full event sourcing |
+| Event-sourced projectors, optimistic concurrency | **Skip for now** | Most complex piece; revisit if we need multi-writer/sync |
+| Effect runtime, `LayerNode` DI | **Skip** | Plain Python DI (constructor injection / FastAPI deps) |
+| mDNS discovery, PTY websocket, plugin system, MCP | **Later** | Not needed for v1 |
+| ai-sdk provider layer | **Skip** | skene's `llm/` already covers this in Python |
+
+---
+
+## 2. Target layout
+
+```
+src/skene/
+  schema/        # NEW: pydantic wire models — single source of truth
+                 #   session.py, message.py (parts, ToolState), event.py,
+                 #   agent.py, permission.py
+  core/          # NEW: domain services (no HTTP)
+                 #   bus.py          in-process pub/sub, typed events
+                 #   store.py        SQLite (aiosqlite) sessions/messages/parts
+                 #   sessions.py     create/prompt/abort/fork, run coordinator
+                 #   agents.py       agent registry (primary vs subagent)
+                 #   tasks.py        the task tool: spawn child sessions
+                 #   permissions.py  ask/allow/deny rulesets  (phase 2)
+                 #   workspace.py    per-directory context cache
+  server/        # NEW: FastAPI app
+                 #   app.py, routes/{session,event,agent,config,provider,file}.py
+                 #   sse.py, auth.py
+  llm/           # existing — unchanged (providers, factory)
+  analyzers/     # existing engine; journey steps become tools/subagents
+  cli/           # thin client: serve, run, analyse-journey (spawns embedded server)
+tui/             # Go — generated client + SSE reader replaces uvx stdout-scraping
+```
+
+The `schema` package mirrors opencode's `@opencode-ai/schema`: everything on the wire
+is defined once in pydantic, FastAPI derives OpenAPI from it, and both the Go TUI
+client and a future TS/web client are generated from that spec.
+
+---
+
+## 3. Domain model
+
+Copied from `packages/schema/src/session-message.ts`, trimmed to what skene renders.
+
+```
+Project   { id, directory, name }
+Session   { id, projectID, parentID?, agent, title, status: idle|running|error,
+            created, updated }
+Message   { id, sessionID, role: user|assistant|synthetic, created,
+            # assistant only:
+            agent, model, tokens, cost, finish }
+Part      { id, messageID, type: text | reasoning | tool | milestone | artifact }
+ToolPart  { tool, callID, state: pending → running → completed | error,
+            input, output, title, metadata }
+```
+
+Two skene-specific part types:
+
+- **`milestone`** — a `CandidateMilestone` emitted by `emit_milestone`. Today these go
+  into an in-memory collector list; as parts they persist, stream to the UI live
+  ("found: user signs up → auth/signup.ts"), and remain queryable per session.
+- **`artifact`** — a produced file (`journey.yaml`), with path + summary, so clients
+  can offer "open visualizer" without knowing engine internals.
+
+**Persistence:** single global SQLite DB at `~/.local/share/skene/skene.db`
+(WAL mode, `aiosqlite`), tables ≈ the model above plus `permission_request`. Write
+state directly and publish an event on every mutation — skip opencode's
+event-sourcing/projector layer (`packages/core/src/event.ts`) until there's a
+multi-writer or sync requirement. Artifacts still land in the workspace
+(`skene-context/journey.yaml`) as today.
+
+**Events** (SSE wire shape `{id, type, properties}`, exactly like opencode):
+
+```
+server.connected, server.heartbeat (10s)
+session.created | updated | idle | error
+message.created | updated
+part.created | updated          # streaming text + tool-state transitions
+permission.asked | answered
+```
+
+---
+
+## 4. API surface
+
+All routes scoped by workspace via `x-skene-directory` header (fallback: server cwd),
+mirroring opencode's `workspace-routing.ts`. Auth: bearer token from `.skene.config`;
+bind 127.0.0.1 by default, token required for non-local binds.
+
+```
+GET  /event                                  SSE stream (filtered by directory)
+
+POST /session                                create {agent?, parentID?, title?}
+GET  /session                                list
+GET  /session/{id}                           get
+GET  /session/{id}/children                  subagent sessions
+GET  /session/{id}/message                   messages + parts
+POST /session/{id}/message                   prompt: returns user Message immediately,
+                                             run proceeds async, progress via /event
+POST /session/{id}/abort                     cancel the running task tree
+POST /session/{id}/permissions/{permID}      answer an ask (phase 2)
+
+GET  /agent                                  registry (primary + subagents)
+GET  /provider                               available providers/models
+GET  /config          PATCH /config          resolved config (secrets redacted)
+
+POST /journey/analyse                        v1-compat convenience: creates a session,
+                                             sends the canned analyse prompt, returns
+                                             {sessionID}; result = artifact part
+GET  /journey                                latest journey.yaml as JSON (replaces the
+                                             TUI visualizer's file read)
+
+GET  /health   GET /doc (openapi.json)
+```
+
+Client generation: CI job runs the server's `openapi.json` through `oapi-codegen`
+(Go, for `tui/`) — same pattern as opencode's `packages/sdk/js/script/build.ts`. SSE
+consumption is a small hand-written reader on each client.
+
+---
+
+## 5. The agentic flow
+
+Requirement #1 restated in opencode's vocabulary: **skene is a primary agent; code
+and db are subagents invoked through a `task` tool; a subagent run is a child
+session** (opencode: `tool/task.ts` + `sessions.create({parentID})`).
+
+### Agent registry
+
+```python
+Agent(
+  name="skene",  mode="primary",
+  prompt=MAIN_AGENT_INSTRUCTIONS,
+  tools=[task, introspect_db, finalize_journey, read_artifact],
+)
+Agent(name="code",   mode="subagent", prompt=CODE_AGENT_INSTRUCTIONS,   toolset=FsToolset)
+Agent(name="schema", mode="subagent", prompt=SCHEMA_AGENT_INSTRUCTIONS, toolset=SchemaToolset)
+# future: analytics, docs, api-surface, ...
+```
+
+The task tool advertises available subagents in its description (opencode's
+`describeTask` pattern), so adding an agent to the registry makes it reachable
+without touching the main agent's prompt.
+
+### Keeping determinism where it earns its keep
+
+Today `run_journey_pipeline` is fully deterministic orchestration: specialize ∥
+schema-agent ∥ code-agent → merge → classify fan-out → assemble. Making the main
+agent free-form would trade reproducibility for nothing. Split it:
+
+- **Agentic:** *which* subagents to spawn, with what focus, whether to re-run one that
+  under-delivered, how to react to a missing schema. The main agent calls
+  `task(agent="code", prompt=...)` and `task(agent="schema", ...)` — in parallel via
+  multiple tool calls in one turn.
+- **Deterministic tools:** `introspect_db(db_url)` (thread-executor around the sync
+  psycopg call), `finalize_journey()` (merge + classify fan-out + assemble +
+  serialize — the current post-agent pipeline verbatim, exposed as one tool that
+  reads milestone parts from child sessions).
+
+`analyse-journey` then becomes a **canned prompt** to a fresh skene session (opencode's
+"command" concept) — same UX, but every run is now inspectable as a session tree, and
+"add an analytics agent" is a registry entry plus a prompt tweak.
+
+### Engine refactor: the one real surgery
+
+`agent_loop.run_agent()` (`src/skene/llm/agent_loop.py:171`) currently runs to
+completion and returns a result — nothing streams. It must become event-emitting:
+
+```python
+async def run_agent(...) -> AsyncIterator[AgentEvent]:
+    # yields: turn_started, text_delta, tool_call_started(callID, name, input),
+    #         tool_call_finished(callID, output|error), turn_finished, run_finished
+```
+
+plus cooperative cancellation (checked between turns and passed into tool handlers).
+The session **run coordinator** in `core/sessions.py` consumes this iterator,
+persists parts, and publishes bus events — the loop itself stays free of HTTP and
+storage concerns, as it is today. `LLMClient` and the providers don't change;
+existing `Tool`/toolset classes are reused as-is, gaining an optional `context`
+(sessionID, abort signal, `ask()` for permissions later).
+
+Everything else in the engine is reused untouched: pipeline steps become tool
+bodies, `FsToolset`/`SchemaToolset` become subagent toolsets, `llm/factory.py`
+becomes the provider service.
+
+---
+
+## 6. Clients
+
+**CLI** (`src/skene/cli/`):
+- `skene serve [--port 4906] [--host]` — run the server headless.
+- `skene analyse-journey ...` — unchanged UX: starts an embedded server (in-process
+  lifespan, no socket needed — call `core` directly), creates a session, sends the
+  canned prompt, renders `/event` progress with rich. This is opencode's `run`.
+- `skene attach <url>` — later, once remote serving matters.
+
+**TUI** (`tui/`): the entire `internal/services/growth/engine.go` uvx-spawn +
+stdout-scraping + stall-timer machinery is deleted. The TUI either spawns
+`skene serve` (owning the process) or connects to a running one, then drives the
+generated Go client and renders the SSE stream. Wins: real structured progress
+(per-agent, per-tool), reliable interactive prompts via the permission/question flow
+instead of stdin heuristics, and the visualizer reads `GET /journey` instead of
+parsing `journey.yaml` itself.
+
+---
+
+## 7. Cross-cutting watch-outs
+
+- **Blocking introspection:** `postgres_live.introspect_db` is sync psycopg inside an
+  async server — wrap in `asyncio.to_thread`. Same for any tree-sitter/sqlglot
+  hot spots if they show up in traces.
+- **Secrets:** `db_url` is deliberately never persisted today
+  (`analyse_journey.py`, `_redact_db_url`). Preserve that: it may appear in a tool
+  *input* on the wire → redact DSNs in persisted/streamed tool inputs. API keys are
+  per-request/per-config, never in the DB, redacted in `GET /config`.
+- **Concurrency isolation:** collectors are currently in-memory globals per run;
+  milestone-as-part removes them, but audit the engine for any other module-level
+  state before serving concurrent sessions.
+- **Session cleanup:** abort must cancel the whole child-session tree (opencode
+  does this through the parent abort signal).
+
+---
+
+## 8. Phased plan
+
+1. **Schema + streaming loop.** Create `skene/schema` (session/message/part/event
+   models); refactor `agent_loop.run_agent` into an event-yielding iterator with
+   cancellation. Engine still runnable via the old CLI (adapter that drains the
+   iterator). Smallest reviewable slice, unlocks everything.
+2. **Server MVP.** `skene/core` (bus, store, sessions) + FastAPI app: session CRUD,
+   prompt, abort, `/event` SSE, `/journey/analyse` compat route running the current
+   deterministic pipeline inside a session. CLI `serve` command; `analyse-journey`
+   switched to embedded-server mode.
+3. **Agentic flow.** Agent registry, task tool, child sessions; recast code/schema
+   agents as subagents and `analyse-journey` as the canned main-agent prompt;
+   `finalize_journey` tool. Retire the standalone pipeline path once output parity
+   is verified against golden `journey.yaml` fixtures.
+4. **TUI cutover.** Generate the Go client, replace `growth/engine.go`, wire the
+   visualizer to `GET /journey`. Delete stdout parsing.
+5. **Hardening & growth.** Permission ask flow, `attach` + auth for remote serving,
+   additional subagents, optional durable event log if sync/multi-client demands it.
+
+Phases 1–3 keep `main` shippable throughout: the old code path stays until phase 3's
+parity check passes.
+
+---
+
+## 9. Resolved questions (2026-07-06)
+
+- **Session retention: keep everything.** No GC; sessions are the debug trace for
+  every analysis. Add a `skene sessions prune` command later if the DB ever becomes
+  a problem, but don't build it now.
+- **Multi-tenancy: not in scope.** Same posture as opencode: single-tenant server,
+  per-server token, per-directory workspace scoping. One global SQLite under one OS
+  user; Skene Cloud stays a separate service the client pushes to. "One shared
+  server, many users" is explicitly a non-goal — if that ever changes it's a
+  redesign of auth/storage, not a bolt-on.
+- **Interactive main agent: start with the canned prompt.** v1 clients only trigger
+  the canned analyse prompt; no free-form chat with the skene agent. The API
+  (`POST /session/{id}/message`) already supports arbitrary follow-up messages, so
+  enabling chat later is TUI/CLI scope, not a server change.

--- a/docs/design/backend-server.md
+++ b/docs/design/backend-server.md
@@ -1,6 +1,15 @@
 # Skene Backend Server — Design
 
-Status: draft (2026-07-06)
+Status: in progress (2026-07-06) — phase 1 implemented, phases 2-5 pending.
+Work lands on feature branches targeting the `v1.0` integration branch.
+
+| Phase | Status | Where |
+|---|---|---|
+| 1. Schema + streaming loop | **done** | `feat/server-phase1` |
+| 2. Server MVP | pending | |
+| 3. Agentic flow | pending | |
+| 4. TUI cutover | pending | |
+| 5. Hardening & growth | pending | |
 
 Goal: turn skene into a client/server system where a **main skene agent** orchestrates
 **code/db subagents** (and future ones), and CLI + TUI are thin clients of a single
@@ -291,6 +300,43 @@ parsing `journey.yaml` itself.
 
 Phases 1–3 keep `main` shippable throughout: the old code path stays until phase 3's
 parity check passes.
+
+### Phase 1 — as built (notes for phase 2+)
+
+What exists after phase 1 (`feat/server-phase1`), and the contracts the next
+phases build on:
+
+- **`skene/schema`** is the wire-model package. Conventions baked in: camelCase
+  JSON / snake_case Python (`WireModel` base in `schema/base.py` sets
+  `alias_generator=to_camel`, `populate_by_name`, `serialize_by_alias`,
+  `extra="forbid"` — new wire models must inherit from it); discriminated unions
+  `Message` (by `role`), `Part` (by `type`), `ToolState` (by `status`), `Event`
+  (by `type`); IDs from `schema/ids.py` `new_id(prefix)` — prefixed
+  (`ses_/msg_/prt_/evt_/prj_`), time-sortable, monotonic **per process only**
+  (don't rely on cross-process ordering; the store's `created` column is the
+  cross-process truth).
+- **Streaming loop**: `agent_loop.run_agent_stream()` yields `TurnStarted`,
+  `AssistantText`, `ToolCallStarted`, `ToolCallFinished(error: bool)`, then
+  always `RunFinished(result)`. `run_agent()` is a draining wrapper (the batch
+  CLI path uses it unchanged). Reach it via `LLMClient.run_agent_stream(...)` so
+  provider overrides keep working. Phase 2's run coordinator maps events →
+  parts: `TurnStarted`+`AssistantText` → `TextPart`, `ToolCallStarted` →
+  `ToolPart(state=running)`, `ToolCallFinished` → `completed`/`error` state.
+  Note: providers return full turns, so there are no token-level text deltas
+  yet — `PartUpdated.delta` is wired but per-turn granularity for now; true
+  token streaming needs `generate_with_tools` streaming variants (later, not
+  phase 2 scope).
+- **Cancellation**: `abort: asyncio.Event`, checked before each LLM call and
+  each tool dispatch. It does **not** interrupt an in-flight provider call —
+  the phase-2 abort endpoint should set the event *and* cancel the session's
+  asyncio task, and must fan out to child-session tasks (phase 3).
+- **Aborted history caveat**: an aborted run's message list can end on an
+  assistant message with unanswered tool calls. If a session is ever resumed
+  from stored history, synthesize `tool` results for the dangling calls first —
+  providers reject histories with unanswered tool calls.
+- **Deliberate loose end**: `MilestonePart.milestone` is `dict[str, Any]`.
+  Phase 3 moves `CandidateMilestone`/`Evidence` into `skene/schema` (analyzers
+  re-export) and types it — do this when recasting the agents, not before.
 
 ---
 

--- a/src/skene/llm/agent_loop.py
+++ b/src/skene/llm/agent_loop.py
@@ -9,7 +9,13 @@ This module defines:
   API.
 - :class:`AgentRunResult` — what the loop returns: the final assistant
   text, the full message history, and aggregate usage.
-- :func:`run_agent` — the default loop. Providers can override
+- :func:`run_agent_stream` — the default loop, as an async generator that
+  yields :data:`AgentStreamEvent` items (turn boundaries, assistant text,
+  tool-call start/finish) while it runs, ending with :class:`RunFinished`.
+  This is what the server's session runner consumes to persist parts and
+  publish bus events.
+- :func:`run_agent` — drains the stream and returns the final
+  :class:`AgentRunResult`. Providers can override
   :meth:`LLMClient.run_agent` if they need different semantics, but the
   default is shared.
 
@@ -18,7 +24,10 @@ that raises has its exception caught and stringified back to the model as
 the tool result, so the agent can recover. The loop stops when:
 
 - The model returns an assistant turn with no tool calls, OR
-- ``max_turns`` is reached (counted from 1 per LLM call).
+- ``max_turns`` is reached (counted from 1 per LLM call), OR
+- the ``abort`` event is set (checked before each LLM call and before each
+  tool dispatch — a cheap cooperative cancel; in-flight awaits are not
+  interrupted, cancel the task for that).
 
 We deliberately do NOT expose a "this tool terminates the loop" hook —
 journeygen relies on the model deciding it has nothing more to do. The
@@ -30,7 +39,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -112,8 +121,57 @@ class AgentRunResult:
     final_text: str | None
     messages: list[Message]
     turns: int
-    stopped_reason: str  # "no_tool_calls" | "max_turns"
+    stopped_reason: str  # "no_tool_calls" | "max_turns" | "aborted"
     usage: dict[str, int] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Stream events
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TurnStarted:
+    """About to make LLM call number ``turn`` (1-based)."""
+
+    turn: int
+
+
+@dataclass
+class AssistantText:
+    """The model produced text this turn (may accompany tool calls)."""
+
+    turn: int
+    text: str
+
+
+@dataclass
+class ToolCallStarted:
+    """About to dispatch a tool handler."""
+
+    turn: int
+    call: ToolCall
+
+
+@dataclass
+class ToolCallFinished:
+    """A tool handler returned (or failed — ``error`` is True and ``result``
+    is the stringified error the model will see)."""
+
+    turn: int
+    call: ToolCall
+    result: str
+    error: bool = False
+
+
+@dataclass
+class RunFinished:
+    """Always the last event of a stream."""
+
+    result: AgentRunResult
+
+
+AgentStreamEvent = TurnStarted | AssistantText | ToolCallStarted | ToolCallFinished | RunFinished
 
 
 async def _invoke_handler(handler: ToolHandler, arguments: dict[str, Any]) -> str:
@@ -129,17 +187,22 @@ async def _invoke_handler(handler: ToolHandler, arguments: dict[str, Any]) -> st
     return result
 
 
-async def run_agent(
+async def run_agent_stream(
     client: Any,  # LLMClient — typed as Any to avoid circular import
     instructions: str,
     tools: list[Tool],
     initial_input: str,
     max_turns: int = 20,
-) -> AgentRunResult:
-    """Run the agent loop until the model stops calling tools.
+    abort: asyncio.Event | None = None,
+) -> AsyncGenerator[AgentStreamEvent, None]:
+    """Run the agent loop, yielding events as it goes.
 
     ``client`` must implement ``generate_with_tools(messages, tools)``. The
     handlers in ``tools`` are dispatched here; the client never sees them.
+
+    The last event is always :class:`RunFinished`. When ``abort`` is set the
+    run finishes with ``stopped_reason="aborted"``; the message history may
+    then end on an assistant turn whose tool calls were never answered.
     """
     tools_by_name = {t.name: t for t in tools}
     if len(tools_by_name) != len(tools):
@@ -153,7 +216,27 @@ async def run_agent(
     agg_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
     seen_any_usage = False
 
+    def _finish(final_text: str | None, turns: int, stopped_reason: str) -> RunFinished:
+        return RunFinished(
+            AgentRunResult(
+                final_text=final_text,
+                messages=messages,
+                turns=turns,
+                stopped_reason=stopped_reason,
+                usage=agg_usage if seen_any_usage else None,
+            )
+        )
+
+    def _aborted() -> bool:
+        return abort is not None and abort.is_set()
+
     for turn_idx in range(1, max_turns + 1):
+        if _aborted():
+            debug(f"agent loop aborted before turn {turn_idx}")
+            yield _finish(None, turn_idx - 1, "aborted")
+            return
+
+        yield TurnStarted(turn_idx)
         turn: AssistantTurn = await client.generate_with_tools(messages, tools)
 
         if turn.usage:
@@ -171,22 +254,27 @@ async def run_agent(
                 tool_calls=list(turn.tool_calls),
             )
         )
+        if turn.text:
+            yield AssistantText(turn_idx, turn.text)
 
         if not turn.tool_calls:
             debug(f"agent loop done after {turn_idx} turn(s): no tool calls")
-            return AgentRunResult(
-                final_text=turn.text,
-                messages=messages,
-                turns=turn_idx,
-                stopped_reason="no_tool_calls",
-                usage=agg_usage if seen_any_usage else None,
-            )
+            yield _finish(turn.text, turn_idx, "no_tool_calls")
+            return
 
         # Dispatch each tool call sequentially. Order matches what the model emitted.
         for tc in turn.tool_calls:
+            if _aborted():
+                debug(f"agent loop aborted during turn {turn_idx}")
+                yield _finish(None, turn_idx, "aborted")
+                return
+
+            yield ToolCallStarted(turn_idx, tc)
+            is_error = False
             tool = tools_by_name.get(tc.name)
             if tool is None:
                 result_str = json.dumps({"error": f"unknown tool {tc.name!r}; available: {sorted(tools_by_name)}"})
+                is_error = True
                 warning(f"agent called unknown tool {tc.name!r}")
             else:
                 try:
@@ -196,6 +284,8 @@ async def run_agent(
                 except Exception as e:  # noqa: BLE001 — tool errors are recoverable
                     warning(f"tool {tc.name} raised: {e}")
                     result_str = json.dumps({"error": f"{type(e).__name__}: {e}"})
+                    is_error = True
+            yield ToolCallFinished(turn_idx, tc, result_str, error=is_error)
             messages.append(
                 Message(
                     role="tool",
@@ -206,10 +296,30 @@ async def run_agent(
             )
 
     warning(f"agent loop hit max_turns={max_turns} without finishing")
-    return AgentRunResult(
-        final_text=None,
-        messages=messages,
-        turns=max_turns,
-        stopped_reason="max_turns",
-        usage=agg_usage if seen_any_usage else None,
-    )
+    yield _finish(None, max_turns, "max_turns")
+
+
+async def run_agent(
+    client: Any,  # LLMClient — typed as Any to avoid circular import
+    instructions: str,
+    tools: list[Tool],
+    initial_input: str,
+    max_turns: int = 20,
+    abort: asyncio.Event | None = None,
+) -> AgentRunResult:
+    """Run the agent loop to completion and return only the final result.
+
+    Convenience wrapper over :func:`run_agent_stream` for callers that don't
+    need progress events (the batch CLI path, tests).
+    """
+    async for event in run_agent_stream(
+        client,
+        instructions=instructions,
+        tools=tools,
+        initial_input=initial_input,
+        max_turns=max_turns,
+        abort=abort,
+    ):
+        if isinstance(event, RunFinished):
+            return event.result
+    raise RuntimeError("agent stream ended without RunFinished")

--- a/src/skene/llm/base.py
+++ b/src/skene/llm/base.py
@@ -2,11 +2,12 @@
 Abstract base class for LLM clients.
 """
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, AsyncGenerator
 
 if TYPE_CHECKING:
-    from skene.llm.agent_loop import AgentRunResult, AssistantTurn, Message, Tool
+    from skene.llm.agent_loop import AgentRunResult, AgentStreamEvent, AssistantTurn, Message, Tool
 
 
 class LLMClient(ABC):
@@ -89,6 +90,7 @@ class LLMClient(ABC):
         tools: "list[Tool]",
         initial_input: str,
         max_turns: int = 20,
+        abort: asyncio.Event | None = None,
     ) -> "AgentRunResult":
         """Run an agent loop, dispatching tool calls until the model stops.
 
@@ -105,4 +107,30 @@ class LLMClient(ABC):
             tools=tools,
             initial_input=initial_input,
             max_turns=max_turns,
+            abort=abort,
+        )
+
+    def run_agent_stream(
+        self,
+        instructions: str,
+        tools: "list[Tool]",
+        initial_input: str,
+        max_turns: int = 20,
+        abort: asyncio.Event | None = None,
+    ) -> "AsyncGenerator[AgentStreamEvent, None]":
+        """Run the agent loop, yielding progress events; see
+        :func:`skene.llm.agent_loop.run_agent_stream`.
+
+        The server's session runner consumes this to persist message parts
+        and publish bus events while the agent works.
+        """
+        from skene.llm.agent_loop import run_agent_stream
+
+        return run_agent_stream(
+            self,
+            instructions=instructions,
+            tools=tools,
+            initial_input=initial_input,
+            max_turns=max_turns,
+            abort=abort,
         )

--- a/src/skene/schema/__init__.py
+++ b/src/skene/schema/__init__.py
@@ -1,0 +1,81 @@
+"""Wire-format models shared by the server, CLI, and TUI clients.
+
+This package is the single source of truth for everything that crosses the
+HTTP/SSE boundary (see ``docs/design/backend-server.md``). FastAPI derives
+the OpenAPI spec from these models, and client SDKs are generated from that
+spec — so changes here are wire-format changes.
+
+JSON uses camelCase (``session.parentId``); Python uses snake_case. All
+models accept both on input.
+"""
+
+from skene.schema.agent import AgentInfo, AgentMode
+from skene.schema.event import (
+    Event,
+    MessageCreated,
+    MessageUpdated,
+    PartCreated,
+    PartUpdated,
+    ServerConnected,
+    ServerHeartbeat,
+    SessionCreated,
+    SessionError,
+    SessionIdle,
+    SessionUpdated,
+)
+from skene.schema.ids import new_id
+from skene.schema.message import (
+    ArtifactPart,
+    AssistantMessage,
+    Message,
+    MilestonePart,
+    Part,
+    ReasoningPart,
+    SyntheticMessage,
+    TextPart,
+    TokenUsage,
+    ToolPart,
+    ToolState,
+    ToolStateCompleted,
+    ToolStateError,
+    ToolStatePending,
+    ToolStateRunning,
+    UserMessage,
+)
+from skene.schema.session import Project, Session, SessionStatus
+
+__all__ = [
+    "AgentInfo",
+    "AgentMode",
+    "ArtifactPart",
+    "AssistantMessage",
+    "Event",
+    "Message",
+    "MessageCreated",
+    "MessageUpdated",
+    "MilestonePart",
+    "Part",
+    "PartCreated",
+    "PartUpdated",
+    "Project",
+    "ReasoningPart",
+    "ServerConnected",
+    "ServerHeartbeat",
+    "Session",
+    "SessionCreated",
+    "SessionError",
+    "SessionIdle",
+    "SessionStatus",
+    "SessionUpdated",
+    "SyntheticMessage",
+    "TextPart",
+    "TokenUsage",
+    "ToolPart",
+    "ToolState",
+    "ToolStateCompleted",
+    "ToolStateError",
+    "ToolStatePending",
+    "ToolStateRunning",
+    "UserMessage",
+    "new_id",
+]

--- a/src/skene/schema/agent.py
+++ b/src/skene/schema/agent.py
@@ -1,0 +1,23 @@
+"""Agent registry wire model."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from skene.schema.base import WireModel
+
+AgentMode = Literal["primary", "subagent"]
+
+
+class AgentInfo(WireModel):
+    """A registered agent as exposed by ``GET /agent``.
+
+    ``primary`` agents are user-selectable; ``subagent`` agents are only
+    reachable through a primary agent's ``task`` tool.
+    """
+
+    name: str
+    mode: AgentMode
+    description: str | None = None
+    model: str | None = None
+    hidden: bool = False

--- a/src/skene/schema/base.py
+++ b/src/skene/schema/base.py
@@ -1,0 +1,21 @@
+"""Shared pydantic base for all wire models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class WireModel(BaseModel):
+    """Base for everything serialized over the API.
+
+    camelCase on the wire, snake_case in Python. ``extra="forbid"`` so
+    typos in client payloads fail loudly instead of being dropped.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="forbid",
+        serialize_by_alias=True,
+    )

--- a/src/skene/schema/event.py
+++ b/src/skene/schema/event.py
@@ -1,0 +1,124 @@
+"""Server-sent event wire models.
+
+Every event is ``{id, type, properties}`` on the wire (opencode's SSE
+shape). ``Event`` is the discriminated union streamed from ``GET /event``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Union
+
+from pydantic import Field
+
+from skene.schema.base import WireModel
+from skene.schema.ids import new_id
+from skene.schema.message import Message, Part
+from skene.schema.session import Session
+
+
+def _event_id() -> str:
+    return new_id("evt")
+
+
+class _BaseEvent(WireModel):
+    id: str = Field(default_factory=_event_id)
+
+
+# --- server lifecycle ------------------------------------------------------
+
+
+class _Empty(WireModel):
+    pass
+
+
+class ServerConnected(_BaseEvent):
+    type: Literal["server.connected"] = "server.connected"
+    properties: _Empty = Field(default_factory=_Empty)
+
+
+class ServerHeartbeat(_BaseEvent):
+    type: Literal["server.heartbeat"] = "server.heartbeat"
+    properties: _Empty = Field(default_factory=_Empty)
+
+
+# --- sessions ---------------------------------------------------------------
+
+
+class _SessionProps(WireModel):
+    session: Session
+
+
+class SessionCreated(_BaseEvent):
+    type: Literal["session.created"] = "session.created"
+    properties: _SessionProps
+
+
+class SessionUpdated(_BaseEvent):
+    type: Literal["session.updated"] = "session.updated"
+    properties: _SessionProps
+
+
+class SessionIdle(_BaseEvent):
+    type: Literal["session.idle"] = "session.idle"
+    properties: _SessionProps
+
+
+class _SessionErrorProps(WireModel):
+    session: Session
+    error: str
+
+
+class SessionError(_BaseEvent):
+    type: Literal["session.error"] = "session.error"
+    properties: _SessionErrorProps
+
+
+# --- messages & parts -------------------------------------------------------
+
+
+class _MessageProps(WireModel):
+    message: Message
+
+
+class MessageCreated(_BaseEvent):
+    type: Literal["message.created"] = "message.created"
+    properties: _MessageProps
+
+
+class MessageUpdated(_BaseEvent):
+    type: Literal["message.updated"] = "message.updated"
+    properties: _MessageProps
+
+
+class _PartProps(WireModel):
+    part: Part
+    # For streaming text parts: the appended suffix since the last event, so
+    # clients can render deltas without diffing the full part.
+    delta: str | None = None
+
+
+class PartCreated(_BaseEvent):
+    type: Literal["part.created"] = "part.created"
+    properties: _PartProps
+
+
+class PartUpdated(_BaseEvent):
+    type: Literal["part.updated"] = "part.updated"
+    properties: _PartProps
+
+
+Event = Annotated[
+    Union[
+        ServerConnected,
+        ServerHeartbeat,
+        SessionCreated,
+        SessionUpdated,
+        SessionIdle,
+        SessionError,
+        MessageCreated,
+        MessageUpdated,
+        PartCreated,
+        PartUpdated,
+    ],
+    Field(discriminator="type"),
+]

--- a/src/skene/schema/ids.py
+++ b/src/skene/schema/ids.py
@@ -1,0 +1,28 @@
+"""Prefixed, time-sortable identifiers (``ses_``, ``msg_``, ``prt_``, ``evt_``).
+
+The prefix makes IDs self-describing in logs and DB rows; the millisecond
+timestamp prefix makes lexicographic order match creation order, so SQLite
+range scans over IDs are chronological without an extra column.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+
+# Fixed-width hex millisecond timestamp: 12 hex chars covers year ~10889.
+_TS_WIDTH = 12
+
+# IDs minted in the same millisecond would otherwise sort by their random
+# suffix; bump a monotonic floor so per-process creation order always holds.
+_last_ts = 0
+_lock = threading.Lock()
+
+
+def new_id(prefix: str) -> str:
+    global _last_ts
+    with _lock:
+        ts = max(int(time.time() * 1000), _last_ts + 1)
+        _last_ts = ts
+    return f"{prefix}_{ts:0{_TS_WIDTH}x}{secrets.token_hex(6)}"

--- a/src/skene/schema/message.py
+++ b/src/skene/schema/message.py
@@ -1,0 +1,152 @@
+"""Message and part wire models.
+
+Shapes follow opencode's tagged-union message/part design
+(``packages/schema/src/session-message.ts``): a message is discriminated by
+``role``, its content is a list of parts discriminated by ``type``, and tool
+parts carry a ``ToolState`` discriminated by ``status`` that transitions
+``pending -> running -> completed | error``. Clients render parts
+incrementally as ``part.updated`` events stream in.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import Field
+
+from skene.schema.base import WireModel
+
+# ---------------------------------------------------------------------------
+# Tool state
+# ---------------------------------------------------------------------------
+
+
+class ToolStatePending(WireModel):
+    status: Literal["pending"] = "pending"
+
+
+class ToolStateRunning(WireModel):
+    status: Literal["running"] = "running"
+    input: dict[str, Any] = Field(default_factory=dict)
+    title: str | None = None
+    started: int | None = None  # epoch ms
+
+
+class ToolStateCompleted(WireModel):
+    status: Literal["completed"] = "completed"
+    input: dict[str, Any] = Field(default_factory=dict)
+    output: str = ""
+    title: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    started: int | None = None
+    ended: int | None = None
+
+
+class ToolStateError(WireModel):
+    status: Literal["error"] = "error"
+    input: dict[str, Any] = Field(default_factory=dict)
+    error: str = ""
+    started: int | None = None
+    ended: int | None = None
+
+
+ToolState = Annotated[
+    Union[ToolStatePending, ToolStateRunning, ToolStateCompleted, ToolStateError],
+    Field(discriminator="status"),
+]
+
+# ---------------------------------------------------------------------------
+# Parts
+# ---------------------------------------------------------------------------
+
+
+class _BasePart(WireModel):
+    id: str
+    session_id: str
+    message_id: str
+
+
+class TextPart(_BasePart):
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ReasoningPart(_BasePart):
+    type: Literal["reasoning"] = "reasoning"
+    text: str
+
+
+class ToolPart(_BasePart):
+    type: Literal["tool"] = "tool"
+    tool: str
+    call_id: str
+    state: ToolState
+
+
+class MilestonePart(_BasePart):
+    """A candidate milestone emitted by an analysis agent's ``emit_milestone``.
+
+    ``milestone`` is the serialized
+    :class:`skene.analyzers.journey.candidate.CandidateMilestone`. Kept as a
+    plain dict until phase 3 moves the analyzer models onto this package —
+    at which point this becomes a typed reference (single source of truth).
+    """
+
+    type: Literal["milestone"] = "milestone"
+    milestone: dict[str, Any]
+
+
+class ArtifactPart(_BasePart):
+    """A file the run produced (e.g. ``journey.yaml``)."""
+
+    type: Literal["artifact"] = "artifact"
+    path: str
+    title: str | None = None
+    summary: str | None = None
+
+
+Part = Annotated[
+    Union[TextPart, ReasoningPart, ToolPart, MilestonePart, ArtifactPart],
+    Field(discriminator="type"),
+]
+
+# ---------------------------------------------------------------------------
+# Messages
+# ---------------------------------------------------------------------------
+
+
+class TokenUsage(WireModel):
+    input: int = 0
+    output: int = 0
+
+
+class _BaseMessage(WireModel):
+    id: str
+    session_id: str
+    created: int  # epoch ms
+
+
+class UserMessage(_BaseMessage):
+    role: Literal["user"] = "user"
+
+
+class AssistantMessage(_BaseMessage):
+    role: Literal["assistant"] = "assistant"
+    agent: str
+    provider: str | None = None
+    model: str | None = None
+    tokens: TokenUsage | None = None
+    finish: str | None = None  # "no_tool_calls" | "max_turns" | "aborted" | "error"
+    error: str | None = None
+
+
+class SyntheticMessage(_BaseMessage):
+    """Server-injected content, e.g. a subagent result surfaced to its parent."""
+
+    role: Literal["synthetic"] = "synthetic"
+
+
+Message = Annotated[
+    Union[UserMessage, AssistantMessage, SyntheticMessage],
+    Field(discriminator="role"),
+]

--- a/src/skene/schema/session.py
+++ b/src/skene/schema/session.py
@@ -1,0 +1,34 @@
+"""Project and session wire models."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from skene.schema.base import WireModel
+
+SessionStatus = Literal["idle", "running", "error"]
+
+
+class Project(WireModel):
+    """A workspace directory the server has analyzed."""
+
+    id: str
+    directory: str
+    name: str | None = None
+
+
+class Session(WireModel):
+    """One agent conversation.
+
+    Subagent runs are child sessions: ``parent_id`` points at the session
+    whose ``task`` tool spawned them.
+    """
+
+    id: str
+    project_id: str
+    parent_id: str | None = None
+    agent: str
+    title: str | None = None
+    status: SessionStatus = "idle"
+    created: int  # epoch ms
+    updated: int  # epoch ms

--- a/tests/test_llm/test_agent_stream.py
+++ b/tests/test_llm/test_agent_stream.py
@@ -1,0 +1,222 @@
+"""Tests for the streaming agent loop (run_agent_stream) and cancellation."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncGenerator
+
+from skene.llm.agent_loop import (
+    AgentStreamEvent,
+    AssistantText,
+    AssistantTurn,
+    Message,
+    RunFinished,
+    Tool,
+    ToolCall,
+    ToolCallFinished,
+    ToolCallStarted,
+    TurnStarted,
+)
+from skene.llm.base import LLMClient
+
+
+class _ScriptedClient(LLMClient):
+    """Returns a queued AssistantTurn on each generate_with_tools call."""
+
+    def __init__(self, turns: list[AssistantTurn]) -> None:
+        self._turns = list(turns)
+
+    async def generate_content_with_usage(self, prompt: str) -> tuple[str, dict[str, int] | None]:
+        raise NotImplementedError
+
+    async def generate_content_stream(self, prompt: str) -> AsyncGenerator[str, None]:
+        if False:
+            yield ""
+        raise NotImplementedError
+
+    def get_model_name(self) -> str:
+        return "scripted"
+
+    def get_provider_name(self) -> str:
+        return "scripted"
+
+    async def generate_with_tools(self, messages: list[Message], tools: list[Tool]) -> AssistantTurn:
+        if not self._turns:
+            raise AssertionError("scripted client ran out of turns")
+        return self._turns.pop(0)
+
+
+def _echo_tool() -> Tool:
+    async def handler(args: dict[str, Any]) -> str:
+        return f"echo: {args.get('text', '')}"
+
+    return Tool(
+        name="echo",
+        description="Echo back the text argument.",
+        parameters={
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+        handler=handler,
+    )
+
+
+async def _drain(stream: AsyncGenerator[AgentStreamEvent, None]) -> list[AgentStreamEvent]:
+    return [event async for event in stream]
+
+
+async def test_stream_event_sequence_for_tool_run():
+    client = _ScriptedClient(
+        [
+            AssistantTurn(
+                text="thinking",
+                tool_calls=[
+                    ToolCall(id="c1", name="echo", arguments={"text": "a"}),
+                    ToolCall(id="c2", name="echo", arguments={"text": "b"}),
+                ],
+            ),
+            AssistantTurn(text="done"),
+        ]
+    )
+    events = await _drain(client.run_agent_stream(instructions="", tools=[_echo_tool()], initial_input="go"))
+
+    assert [type(e).__name__ for e in events] == [
+        "TurnStarted",
+        "AssistantText",
+        "ToolCallStarted",
+        "ToolCallFinished",
+        "ToolCallStarted",
+        "ToolCallFinished",
+        "TurnStarted",
+        "AssistantText",
+        "RunFinished",
+    ]
+    first_started = events[2]
+    assert isinstance(first_started, ToolCallStarted)
+    assert first_started.call.id == "c1"
+    first_finished = events[3]
+    assert isinstance(first_finished, ToolCallFinished)
+    assert first_finished.result == "echo: a"
+    assert first_finished.error is False
+    text = events[1]
+    assert isinstance(text, AssistantText)
+    assert text.text == "thinking" and text.turn == 1
+    finished = events[-1]
+    assert isinstance(finished, RunFinished)
+    assert finished.result.stopped_reason == "no_tool_calls"
+    assert finished.result.final_text == "done"
+
+
+async def test_stream_marks_tool_errors():
+    def _bad() -> Tool:
+        async def handler(args: dict[str, Any]) -> str:
+            raise RuntimeError("boom")
+
+        return Tool(name="bad", description="", parameters={"type": "object", "properties": {}}, handler=handler)
+
+    client = _ScriptedClient(
+        [
+            AssistantTurn(tool_calls=[ToolCall(id="c1", name="bad", arguments={})]),
+            AssistantTurn(tool_calls=[ToolCall(id="c2", name="ghost", arguments={})]),
+            AssistantTurn(text="ok"),
+        ]
+    )
+    events = await _drain(client.run_agent_stream(instructions="", tools=[_bad()], initial_input="go"))
+    finishes = [e for e in events if isinstance(e, ToolCallFinished)]
+    assert [f.error for f in finishes] == [True, True]
+    assert "boom" in finishes[0].result
+    assert "unknown tool" in finishes[1].result
+
+
+async def test_abort_before_first_turn():
+    abort = asyncio.Event()
+    abort.set()
+    client = _ScriptedClient([AssistantTurn(text="never called")])
+    events = await _drain(
+        client.run_agent_stream(instructions="", tools=[_echo_tool()], initial_input="go", abort=abort)
+    )
+    assert len(events) == 1
+    finished = events[0]
+    assert isinstance(finished, RunFinished)
+    assert finished.result.stopped_reason == "aborted"
+    assert finished.result.turns == 0
+    # The scripted turn was never consumed: no LLM call happened.
+    assert client._turns
+
+
+async def test_abort_between_tool_calls():
+    abort = asyncio.Event()
+
+    def _tripwire() -> Tool:
+        async def handler(args: dict[str, Any]) -> str:
+            abort.set()  # abort while the first tool of the turn runs
+            return "ran"
+
+        return Tool(name="trip", description="", parameters={"type": "object", "properties": {}}, handler=handler)
+
+    client = _ScriptedClient(
+        [
+            AssistantTurn(
+                tool_calls=[
+                    ToolCall(id="c1", name="trip", arguments={}),
+                    ToolCall(id="c2", name="trip", arguments={}),
+                ],
+            ),
+            AssistantTurn(text="unreachable"),
+        ]
+    )
+    events = await _drain(
+        client.run_agent_stream(instructions="", tools=[_tripwire()], initial_input="go", abort=abort)
+    )
+    # First call dispatched, second one never started.
+    assert [type(e).__name__ for e in events] == [
+        "TurnStarted",
+        "ToolCallStarted",
+        "ToolCallFinished",
+        "RunFinished",
+    ]
+    finished = events[-1]
+    assert isinstance(finished, RunFinished)
+    assert finished.result.stopped_reason == "aborted"
+    assert finished.result.turns == 1
+
+
+async def test_stream_ends_with_run_finished_on_max_turns():
+    client = _ScriptedClient(
+        [AssistantTurn(tool_calls=[ToolCall(id=f"c{i}", name="echo", arguments={"text": str(i)})]) for i in range(5)]
+    )
+    events = await _drain(
+        client.run_agent_stream(instructions="", tools=[_echo_tool()], initial_input="go", max_turns=2)
+    )
+    finished = events[-1]
+    assert isinstance(finished, RunFinished)
+    assert finished.result.stopped_reason == "max_turns"
+    assert finished.result.turns == 2
+    assert isinstance(events[0], TurnStarted)
+
+
+async def test_run_agent_wrapper_matches_stream_result():
+    def make_client() -> _ScriptedClient:
+        return _ScriptedClient(
+            [
+                AssistantTurn(
+                    text=None,
+                    tool_calls=[ToolCall(id="c1", name="echo", arguments={"text": "x"})],
+                    usage={"input_tokens": 10, "output_tokens": 5},
+                ),
+                AssistantTurn(text="done", usage={"input_tokens": 20, "output_tokens": 8}),
+            ]
+        )
+
+    result = await make_client().run_agent(instructions="", tools=[_echo_tool()], initial_input="go")
+    events = await _drain(make_client().run_agent_stream(instructions="", tools=[_echo_tool()], initial_input="go"))
+    finished = events[-1]
+    assert isinstance(finished, RunFinished)
+    streamed = finished.result
+
+    assert result.final_text == streamed.final_text == "done"
+    assert result.stopped_reason == streamed.stopped_reason == "no_tool_calls"
+    assert result.turns == streamed.turns == 2
+    assert result.usage == streamed.usage == {"input_tokens": 30, "output_tokens": 13}
+    assert [m.role for m in result.messages] == [m.role for m in streamed.messages]

--- a/tests/test_schema/test_wire_models.py
+++ b/tests/test_schema/test_wire_models.py
@@ -1,0 +1,120 @@
+"""Tests for the wire-format models in skene.schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from skene.schema import (
+    AssistantMessage,
+    Event,
+    Message,
+    Part,
+    PartUpdated,
+    Session,
+    SessionCreated,
+    TextPart,
+    TokenUsage,
+    ToolPart,
+    ToolStateCompleted,
+    ToolStateRunning,
+    UserMessage,
+    new_id,
+)
+
+PART = TypeAdapter(Part)
+MESSAGE = TypeAdapter(Message)
+EVENT = TypeAdapter(Event)
+
+
+def _session() -> Session:
+    return Session(
+        id=new_id("ses"),
+        project_id=new_id("prj"),
+        agent="skene",
+        created=1000,
+        updated=1000,
+    )
+
+
+def test_ids_are_prefixed_and_time_sortable():
+    first = new_id("ses")
+    second = new_id("ses")
+    assert first.startswith("ses_")
+    assert first != second
+    assert sorted([second, first]) == [first, second]
+
+
+def test_wire_json_is_camel_case_and_round_trips():
+    msg = AssistantMessage(
+        id=new_id("msg"),
+        session_id="ses_1",
+        created=1000,
+        agent="skene",
+        tokens=TokenUsage(input=10, output=5),
+    )
+    data = msg.model_dump(mode="json")
+    assert "sessionId" in data and "session_id" not in data
+
+    # Round-trip through the discriminated union.
+    back = MESSAGE.validate_python(data)
+    assert isinstance(back, AssistantMessage)
+    assert back == msg
+
+
+def test_message_union_discriminates_on_role():
+    user = MESSAGE.validate_python({"id": "msg_1", "sessionId": "ses_1", "created": 1, "role": "user"})
+    assert isinstance(user, UserMessage)
+    with pytest.raises(ValidationError):
+        MESSAGE.validate_python({"id": "msg_1", "sessionId": "ses_1", "created": 1, "role": "alien"})
+
+
+def test_part_union_discriminates_on_type():
+    raw = {
+        "id": "prt_1",
+        "sessionId": "ses_1",
+        "messageId": "msg_1",
+        "type": "tool",
+        "tool": "read_file",
+        "callId": "c1",
+        "state": {"status": "running", "input": {"path": "x"}, "started": 123},
+    }
+    part = PART.validate_python(raw)
+    assert isinstance(part, ToolPart)
+    assert isinstance(part.state, ToolStateRunning)
+
+    done = part.model_copy(
+        update={"state": ToolStateCompleted(input={"path": "x"}, output="ok", started=123, ended=456)}
+    )
+    assert isinstance(done.state, ToolStateCompleted)
+
+
+def test_extra_fields_are_rejected():
+    with pytest.raises(ValidationError):
+        TextPart(
+            id="prt_1",
+            session_id="ses_1",
+            message_id="msg_1",
+            text="hi",
+            surprise="nope",  # type: ignore[call-arg]
+        )
+
+
+def test_event_envelope_shape_and_union():
+    event = SessionCreated(properties={"session": _session()})
+    data = event.model_dump(mode="json")
+    # opencode SSE wire shape: {id, type, properties}
+    assert set(data) == {"id", "type", "properties"}
+    assert data["type"] == "session.created"
+    assert data["id"].startswith("evt_")
+
+    back = EVENT.validate_python(data)
+    assert isinstance(back, SessionCreated)
+
+
+def test_part_updated_carries_streaming_delta():
+    part = TextPart(id="prt_1", session_id="ses_1", message_id="msg_1", text="hello wo")
+    event = PartUpdated(properties={"part": part, "delta": " wo"})
+    data = event.model_dump(mode="json")
+    assert data["properties"]["delta"] == " wo"
+    assert data["properties"]["part"]["type"] == "text"


### PR DESCRIPTION
## Summary

First slice of the client/server rearchitecture ([design doc](docs/design/backend-server.md), included in this PR): skene becomes a backend service with a main agent spawning code/db subagents, and CLI/TUI become thin clients. Architecture modeled on opencode.

This phase is deliberately engine-only — no server yet, no behavior change for existing commands.

### `skene/schema` — wire-format models (new)

Single source of truth for everything that will cross the future HTTP/SSE boundary:

- `Session`/`Project`; `Message` union (`user`/`assistant`/`synthetic`); `Part` union (`text`, `reasoning`, `tool`, `milestone`, `artifact`) with opencode-style `ToolState` transitions (`pending → running → completed | error`)
- SSE event union with `{id, type, properties}` envelopes (`server.*`, `session.*`, `message.*`, `part.*`)
- camelCase on the wire, snake_case in Python, `extra="forbid"`; prefixed time-sortable IDs (`ses_…`, `msg_…`) with a per-process monotonic guard

### Streaming agent loop

- `agent_loop.run_agent_stream()`: async generator yielding `TurnStarted`, `AssistantText`, `ToolCallStarted`/`ToolCallFinished(error)`, always ending with `RunFinished` — what the phase-2 session runner will consume to persist parts and publish events
- Cooperative cancellation via an `abort` event (checked before each LLM call and each tool dispatch)
- `run_agent()` is now a thin draining wrapper: **zero caller changes**; the code/schema agents and pipeline are untouched, and all pre-existing loop tests now exercise the streaming path
- `LLMClient` gains `run_agent_stream` + `abort` passthrough; providers unchanged

## Test plan

- New: `tests/test_llm/test_agent_stream.py` (event ordering, error marking, abort before-run and mid-turn, max-turns, wrapper/stream parity), `tests/test_schema/test_wire_models.py` (discriminated unions, camelCase round-trips, envelope shape)
- Full suite: 435 passed; ruff check/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)