### PR TITLE
feat: server MVP — core services + FastAPI app + serve/embedded CLI (phase 2)

### DIFF
--- a/docs/design/backend-server.md
+++ b/docs/design/backend-server.md
@@ -55,7 +55,7 @@ close enough to opencode's that a TS rewrite could slot in under the same client
 | Sessions/messages/tagged-union parts with streaming `ToolState` | **Take** | Copy shapes from `packages/schema/src/session-message.ts` |
 | SSE `/event` bus with heartbeat + directory filtering | **Take** | Copy semantics from `handlers/event.ts` |
 | Subagents = child sessions spawned by a `task` tool | **Take** | This *is* requirement #1 |
-| Permission `ask` flow (tool pauses, client answers via HTTP) | **Take** (phase 2) | Needed for db-write tools later |
+| Permission `ask` flow (tool pauses, client answers via HTTP) | **Take** (phase 5) | Needed for db-write tools later |
 | Per-request workspace routing (`x-opencode-directory` header) | **Take** | One server, many projects |
 | `serve` / `run` / `attach` CLI lifecycle | **Take** | Same three verbs |
 | SQLite persistence | **Take, simplified** | Plain relational state + event feed, not full event sourcing |
@@ -353,10 +353,31 @@ builds on:
   `redact.py` (DSN redaction).
 - **Run coordinator**: `SessionService.consume_stream(session, message,
   stream)` maps phase-1 stream events → parts exactly as specified and is
-  the piece phase 3 reuses for subagent runs. `start_run` registers any
-  coroutine as a session's abortable background task; `abort()` sets the
-  cooperative event *and* cancels the task (fan-out to child sessions is
-  phase 3's job). Tool inputs and user text are DSN-redacted before persist.
+  the piece phase 3 reuses for subagent runs. It returns the final
+  `AgentRunResult`; the *caller* owns session status transitions and the
+  assistant message's finish/tokens bookkeeping (see `_chat_run` for the
+  canonical sequence). `start_run` registers any coroutine as a session's
+  abortable background task. Tool inputs and user text are DSN-redacted
+  before persist (`core/redact.py`).
+- **Child-session plumbing already exists**: `SessionService.create_session`
+  takes `parent_id` (validated against the store), `SessionCreateRequest`
+  carries `parentId`, and `GET /session/{id}/children` is live. Phase 3's
+  task tool is: create a child session with `parent_id`, `start_run` a
+  subagent run in it, wait, and surface the result to the parent.
+- **One run per session** (`SessionBusyError` on concurrent prompt).
+  Parallel subagents = one child session each; each `start_run` is an
+  independent entry in `SessionService._runs`. Use `sessions.wait(id)` to
+  join a run (that's how the embedded CLI and the tests do it).
+- **Abort does NOT fan out yet**: child runs are independent asyncio tasks,
+  so cancelling a parent's task does not cancel its children. `abort()`
+  sets the cooperative event and cancels that one session's task. Phase 3
+  must make the parent's abort walk the child-session tree (either the
+  task tool holds child session ids and aborts them in its cancellation
+  path, or `abort()` recurses over `store.list_children`).
+- **`llm_factory` is one global factory** (provider/model resolved once at
+  `skene serve` startup, or the CLI's client in embedded mode). Per-agent
+  model overrides (`AgentInfo.model` is already on the wire) are a phase-3
+  registry concern — thread them through the registry, not the factory.
 - **Prompt runs are placeholder chat** (no tools, generic instructions in
   `sessions._CHAT_INSTRUCTIONS`). Phase 3 swaps in the agent registry +
   task tool here; everything else (parts, events, abort) stays.
@@ -365,8 +386,21 @@ builds on:
   `journey_pipeline` ToolPart (running → completed/error), then milestone /
   artifact / summary-text parts from the result. Live-DB introspection runs
   inside the run via `asyncio.to_thread`; `db_url` is never persisted.
-  Phase 3 replaces this wrapper with the main-agent flow — parity check
-  against golden `journey.yaml` fixtures before deleting it.
+  Phase 3 replaces this wrapper (`core/journey.py`) with the main-agent
+  flow — parity check against golden `journey.yaml` fixtures before
+  deleting it. Contract to preserve for clients: the route returns
+  `{sessionId}` immediately, and a finished run has an `artifact` part
+  pointing at `journey.yaml` plus `session.idle`/`session.error` on the bus.
+  These sessions use `agent="journey"`; phase 3's canned-prompt sessions
+  will be `agent="skene"` — nothing keys off the string yet, but the TUI
+  shouldn't either.
+- **MilestonePart shape mismatch to resolve in phase 3**: the phase-2
+  wrapper emits *final* `Milestone` dumps (post-classification, with a
+  `stage_id` key), because that's what the pipeline returns. Phase 3's
+  live `emit_milestone` parts will be `CandidateMilestone`s (no stage yet)
+  per the phase-1 loose-end note. When typing `MilestonePart.milestone`,
+  pick the candidate shape and drop the phase-2 form with the wrapper —
+  don't try to support both.
 - **Server**: `skene.server.create_app(services=None, *, db_path,
   llm_factory, auth_token)` — pass prebuilt services (tests/embedded) or
   let the lifespan own them (`skene serve`). Routes as designed except

--- a/docs/design/backend-server.md
+++ b/docs/design/backend-server.md
@@ -1,12 +1,12 @@
 # Skene Backend Server — Design
 
-Status: in progress (2026-07-06) — phase 1 implemented, phases 2-5 pending.
+Status: in progress (2026-07-06) — phases 1-2 implemented, phases 3-5 pending.
 Work lands on feature branches targeting the `v1.0` integration branch.
 
 | Phase | Status | Where |
 |---|---|---|
 | 1. Schema + streaming loop | **done** | `feat/server-phase1` |
-| 2. Server MVP | pending | |
+| 2. Server MVP | **done** | `feat/server-phase2` |
 | 3. Agentic flow | pending | |
 | 4. TUI cutover | pending | |
 | 5. Hardening & growth | pending | |
@@ -337,6 +337,48 @@ phases build on:
 - **Deliberate loose end**: `MilestonePart.milestone` is `dict[str, Any]`.
   Phase 3 moves `CandidateMilestone`/`Evidence` into `skene/schema` (analyzers
   re-export) and types it — do this when recasting the agents, not before.
+
+### Phase 2 — as built (notes for phase 3+)
+
+What exists after phase 2 (`feat/server-phase2`), and the contracts phase 3
+builds on:
+
+- **`skene/core`**: `bus.py` (in-process pub/sub; events publish with an
+  optional `directory` — subscribers with a directory filter get matching +
+  server-wide events), `store.py` (aiosqlite, WAL, one global DB; rows keep
+  the full wire JSON in a `data` column plus query columns; `save_message`/
+  `save_part` are upserts), `sessions.py` (`SessionService`), `journey.py`
+  (the canned run), `services.py` (`create_services` wiring; `SKENE_DB_PATH`
+  overrides the DB location), `embedded.py` (in-process entry for the CLI),
+  `redact.py` (DSN redaction).
+- **Run coordinator**: `SessionService.consume_stream(session, message,
+  stream)` maps phase-1 stream events → parts exactly as specified and is
+  the piece phase 3 reuses for subagent runs. `start_run` registers any
+  coroutine as a session's abortable background task; `abort()` sets the
+  cooperative event *and* cancels the task (fan-out to child sessions is
+  phase 3's job). Tool inputs and user text are DSN-redacted before persist.
+- **Prompt runs are placeholder chat** (no tools, generic instructions in
+  `sessions._CHAT_INSTRUCTIONS`). Phase 3 swaps in the agent registry +
+  task tool here; everything else (parts, events, abort) stays.
+- **Journey runs** (`POST /journey/analyse` and the CLI) wrap the untouched
+  deterministic pipeline in a session with coarse parts: one
+  `journey_pipeline` ToolPart (running → completed/error), then milestone /
+  artifact / summary-text parts from the result. Live-DB introspection runs
+  inside the run via `asyncio.to_thread`; `db_url` is never persisted.
+  Phase 3 replaces this wrapper with the main-agent flow — parity check
+  against golden `journey.yaml` fixtures before deleting it.
+- **Server**: `skene.server.create_app(services=None, *, db_path,
+  llm_factory, auth_token)` — pass prebuilt services (tests/embedded) or
+  let the lifespan own them (`skene serve`). Routes as designed except
+  `GET /agent`, `GET /provider`, `GET/PATCH /config` (deferred: registry is
+  phase 3, config surface phase 5). Optional bearer auth; `skene serve`
+  refuses non-local binds without a token. `/doc` returns openapi.json.
+- **CLI**: `skene serve` (new), `skene analyse-journey` now runs through
+  `core.embedded.run_journey_embedded` — same UX (pipeline `status()` lines
+  still print), but every CLI run persists a session trace in the skene DB.
+- **Testing note**: httpx's `ASGITransport` buffers whole responses, so SSE
+  tests drive the generator directly or speak raw ASGI (see
+  `tests/test_server/test_sse.py`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
     "tree-sitter-javascript>=0.23",
     "tree-sitter-typescript>=0.23",
     "psycopg[binary]>=3.2",
+    "fastapi>=0.115",
+    "uvicorn>=0.30",
+    "aiosqlite>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/src/skene/cli/app.py
+++ b/src/skene/cli/app.py
@@ -276,6 +276,7 @@ from skene.cli.commands import (  # noqa: E402, F401
     login,
     plan,
     push,
+    serve,
     status_cmd,
     validate,
 )

--- a/src/skene/cli/commands/analyse_journey.py
+++ b/src/skene/cli/commands/analyse_journey.py
@@ -17,12 +17,6 @@ import typer
 from rich.panel import Panel
 from rich.table import Table
 
-from skene.analyzers.journey.pipeline import (
-    JourneyPipelineConfig,
-    run_journey_pipeline,
-)
-from skene.analyzers.journey.serialize import write as write_journey
-from skene.analyzers.schema_parsers.models import SchemaIndex
 from skene.cli._journey_runner import (
     build_llm,
     require_llm_credentials,
@@ -31,8 +25,11 @@ from skene.cli._journey_runner import (
     resolve_cli_config,
 )
 from skene.cli.app import app
-from skene.output import console, error, status
+from skene.core.embedded import run_journey_embedded
+from skene.core.redact import redact_db_url as _redact_db_url
+from skene.output import console, error
 from skene.output_paths import DEFAULT_OUTPUT_DIR
+from skene.schema import JourneyAnalyseRequest
 
 
 @app.command(name="analyse-journey")
@@ -208,33 +205,25 @@ def analyse_journey_cmd(
     journey_path = resolve_artifact_path(output, "journey.yaml")
     journey_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Introspect live DB if --db-url is set.
-    live_schema_index: SchemaIndex | None = None
-    db_display: str | None = None
-    if db_url is not None:
-        from skene.analyzers.schema_parsers.postgres_live import introspect_db
-
-        db_display = _redact_db_url(db_url)
-        status(f"Introspecting database: {db_display}")
-        try:
-            live_schema_index = introspect_db(db_url)
-        except Exception as e:  # noqa: BLE001 — never leak connection details
-            error(f"Failed to introspect database: {e}")
-            raise typer.Exit(1) from e
-        status(f"Introspection complete: {sum(len(t) for t in live_schema_index.files.values())} tables found")
-
+    db_display = _redact_db_url(db_url) if db_url is not None else None
     resolved_product_name = product_name or _infer_product_name(base_path, schema_path, db_url)
 
-    cfg = JourneyPipelineConfig(
-        repo_root=base_path,
-        schema_dir=schema_path,
-        schema_index=live_schema_index,
+    # The run itself goes through the embedded server core (same code path
+    # as ``POST /journey/analyse``), so this CLI invocation leaves a session
+    # trace in the skene DB like any served run. Live-DB introspection also
+    # happens inside the run; the URL is never persisted.
+    request = JourneyAnalyseRequest(
+        path=str(base_path) if base_path is not None else None,
+        schema_dir=str(schema_path) if schema_path is not None else None,
+        db_url=db_url,
         product_name=resolved_product_name,
+        output=str(journey_path),
         classify_concurrency=classify_concurrency,
         schema_max_turns=schema_max_turns,
         code_max_turns=code_max_turns,
         specialize=not no_specialize,
     )
+    specialize = not no_specialize
 
     _render_kickoff(
         title="skene · analyse-journey",
@@ -244,7 +233,7 @@ def analyse_journey_cmd(
         rc=rc,
         product_name=resolved_product_name,
         journey_path=journey_path,
-        specialize=cfg.specialize,
+        specialize=specialize,
     )
 
     llm = build_llm(rc, resolved_api_key, no_fallback=no_fallback)
@@ -252,12 +241,10 @@ def analyse_journey_cmd(
     import asyncio
 
     try:
-        journey = asyncio.run(run_journey_pipeline(cfg, llm))
+        journey = asyncio.run(run_journey_embedded(request, llm, directory=config_root))
     except Exception as e:  # noqa: BLE001 — surface any failure to the user
         error(f"pipeline failed: {e}")
         raise typer.Exit(1) from e
-
-    write_journey(journey, journey_path)
 
     _render_summary(journey_path, journey)
 
@@ -361,36 +348,6 @@ def _infer_product_name(
     if schema_dir is not None:
         return schema_dir.name or "Product"
     return "Product"
-
-
-def _redact_db_url(url: str) -> str:
-    """Return a display-safe version of a DB URL with password redacted.
-
-    Examples::
-
-        postgresql://user:secret@host:5432/mydb  →  postgresql://user:***@host:5432/mydb
-        postgresql://user@host/mydb              →  postgresql://user@host/mydb
-    """
-    try:
-        if "://" not in url:
-            return "<redacted>"
-
-        scheme, rest = url.split("://", 1)
-
-        if "@" in rest:
-            creds, remainder = rest.split("@", 1)
-            if ":" in creds and not creds.endswith(":"):
-                # Has a password — redact it
-                user = creds.split(":", 1)[0]
-                rest = f"{user}:***@{remainder}"
-            else:
-                rest = f"{creds}@{remainder}"
-        else:
-            rest = rest
-
-        return f"{scheme}://{rest}"
-    except Exception:  # noqa: BLE001
-        return "<redacted>"
 
 
 def _render_kickoff(

--- a/src/skene/cli/commands/serve.py
+++ b/src/skene/cli/commands/serve.py
@@ -1,0 +1,70 @@
+"""Run the skene backend server headless (``skene serve``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from skene.cli.app import app, resolve_cli_config
+from skene.output import console, error
+
+_LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+DEFAULT_PORT = 4906
+
+
+@app.command(name="serve", rich_help_panel="manage")
+def serve_cmd(
+    port: int = typer.Option(DEFAULT_PORT, "--port", help="Port to listen on"),
+    host: str = typer.Option("127.0.0.1", "--host", help="Interface to bind (non-local requires --token)"),
+    token: str | None = typer.Option(
+        None,
+        "--token",
+        envvar="SKENE_SERVER_TOKEN",
+        help="Bearer token clients must present. Required when binding a non-local interface.",
+    ),
+    db_path: Path | None = typer.Option(
+        None,
+        "--db-path",
+        envvar="SKENE_DB_PATH",
+        help="SQLite database location (default: ~/.local/share/skene/skene.db)",
+    ),
+    api_key: str | None = typer.Option(None, "--api-key", envvar="SKENE_API_KEY", help="API key for LLM provider"),
+    provider: str | None = typer.Option(None, "--provider", "-p", help="LLM provider for prompt runs"),
+    model: str | None = typer.Option(None, "--model", "-m", help="LLM model name"),
+    base_url: str | None = typer.Option(None, "--base-url", envvar="SKENE_BASE_URL", help="Base URL for API endpoint"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Suppress status messages"),
+    debug: bool = typer.Option(False, "--debug", help="Show diagnostic messages and log all LLM input/output"),
+) -> None:
+    """
+    Run the skene backend server.
+
+    Serves the HTTP API + SSE event stream that the CLI and TUI clients
+    drive (see ``/doc`` for the OpenAPI spec). Binds 127.0.0.1 by default;
+    binding any other interface requires a bearer token.
+    """
+    import uvicorn
+
+    from skene.server import create_app
+
+    if host not in _LOCAL_HOSTS and token is None:
+        error(f"binding non-local interface {host!r} requires --token (or SKENE_SERVER_TOKEN)")
+        raise typer.Exit(2)
+
+    # Resolve LLM config once at startup; prompt runs build a client lazily so
+    # the server still starts (and serves journey-free routes) without a key.
+    rc = resolve_cli_config(
+        api_key=api_key, provider=provider, model=model, base_url=base_url, quiet=quiet, debug=debug
+    )
+
+    def llm_factory():
+        from skene.cli._journey_runner import build_llm
+
+        if not rc.api_key and not rc.is_local:
+            raise RuntimeError("no LLM credentials configured — restart the server with --api-key or set SKENE_API_KEY")
+        return build_llm(rc, rc.api_key or rc.provider, no_fallback=False)
+
+    server_app = create_app(db_path=db_path, llm_factory=llm_factory, auth_token=token)
+    console.print(f"[bold]skene[/bold] server listening on http://{host}:{port} (provider: {rc.provider})")
+    uvicorn.run(server_app, host=host, port=port, log_level="debug" if debug else "info")

--- a/src/skene/core/__init__.py
+++ b/src/skene/core/__init__.py
@@ -1,0 +1,13 @@
+"""Domain services behind the skene server (no HTTP in here).
+
+``core`` owns state and orchestration: the event bus, the SQLite store,
+the session service (run coordinator), and the journey run. The FastAPI
+layer in :mod:`skene.server` is a thin adapter over these services, and
+the CLI's embedded mode calls them directly without a socket.
+"""
+
+from skene.core.bus import Bus
+from skene.core.services import CoreServices, create_services
+from skene.core.store import Store
+
+__all__ = ["Bus", "CoreServices", "Store", "create_services"]

--- a/src/skene/core/bus.py
+++ b/src/skene/core/bus.py
@@ -1,0 +1,78 @@
+"""In-process pub/sub for wire events.
+
+Every state mutation in ``core`` publishes a :data:`skene.schema.Event`
+here; the SSE route and the CLI's embedded progress renderer subscribe.
+Events are scoped to a workspace ``directory`` so one server can host
+many projects (opencode's directory filtering): a subscriber with a
+directory filter receives that directory's events plus server-wide ones
+(published with ``directory=None``, e.g. heartbeats).
+
+Subscriber queues are unbounded — sessions produce events at LLM speed,
+so a slow consumer buffers a handful of small models, not a firehose.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from skene.schema import Event
+
+
+def normalize_directory(directory: str | Path) -> str:
+    """Canonical form used for directory equality across the server."""
+    return str(Path(directory).expanduser().resolve())
+
+
+class Subscription:
+    """One subscriber's view of the bus. Async-iterate to consume."""
+
+    def __init__(self, bus: Bus, directory: str | None) -> None:
+        self._bus = bus
+        self.directory = directory
+        self._queue: asyncio.Queue[Event | None] = asyncio.Queue()
+
+    def _offer(self, event: Event, directory: str | None) -> None:
+        if self.directory is None or directory is None or directory == self.directory:
+            self._queue.put_nowait(event)
+
+    async def get(self, timeout: float | None = None) -> Event | None:
+        """Next event, or ``None`` on timeout (used for SSE heartbeats)."""
+        if timeout is None:
+            return await self._queue.get()
+        try:
+            return await asyncio.wait_for(self._queue.get(), timeout)
+        except TimeoutError:
+            return None
+
+    def __aiter__(self) -> Subscription:
+        return self
+
+    async def __anext__(self) -> Event:
+        event = await self._queue.get()
+        if event is None:
+            raise StopAsyncIteration
+        return event
+
+    def close(self) -> None:
+        self._bus._unsubscribe(self)
+        self._queue.put_nowait(None)  # unblock a pending get()
+
+
+class Bus:
+    def __init__(self) -> None:
+        self._subscriptions: set[Subscription] = set()
+
+    def subscribe(self, directory: str | Path | None = None) -> Subscription:
+        sub = Subscription(self, normalize_directory(directory) if directory is not None else None)
+        self._subscriptions.add(sub)
+        return sub
+
+    def _unsubscribe(self, sub: Subscription) -> None:
+        self._subscriptions.discard(sub)
+
+    def publish(self, event: Event, *, directory: str | Path | None = None) -> None:
+        """Fan an event out to matching subscribers. Never blocks."""
+        resolved = normalize_directory(directory) if directory is not None else None
+        for sub in list(self._subscriptions):
+            sub._offer(event, resolved)

--- a/src/skene/core/embedded.py
+++ b/src/skene/core/embedded.py
@@ -1,0 +1,40 @@
+"""In-process (no socket) entry points for CLI commands.
+
+The CLI's ``analyse-journey`` is opencode's ``run`` verb: it builds the
+same core services the HTTP server would and drives them directly, so a
+CLI run produces the same persisted session trace as a served one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from skene.analyzers.journey.models import Journey
+from skene.core.journey import start_journey_run
+from skene.core.services import create_services
+from skene.llm.base import LLMClient
+from skene.schema import JourneyAnalyseRequest
+
+
+async def run_journey_embedded(
+    request: JourneyAnalyseRequest,
+    llm: LLMClient,
+    *,
+    directory: Path | str,
+    db_path: Path | str | None = None,
+) -> Journey:
+    """Run the canned journey analysis in an embedded session; returns the Journey.
+
+    Raises whatever the pipeline raised (the session records the error too).
+    """
+    services = await create_services(db_path, llm_factory=lambda: llm)
+    try:
+        handle = await start_journey_run(services.sessions, str(directory), request, llm=llm)
+        try:
+            return await handle.result
+        finally:
+            # The future resolves at the tail of the run task; let the task
+            # itself finish before the store goes away.
+            await services.sessions.wait(handle.session.id)
+    finally:
+        await services.close()

--- a/src/skene/core/journey.py
+++ b/src/skene/core/journey.py
@@ -1,0 +1,290 @@
+"""The canned journey analysis, run inside a session.
+
+Phase 2 keeps the deterministic pipeline exactly as it is
+(:func:`skene.analyzers.journey.pipeline.run_journey_pipeline`) and wraps
+one execution of it in a session so every run is persisted, streamable,
+and abortable. The wrapper emits coarse-grained parts — one ``ToolPart``
+for the pipeline, then milestone/artifact/summary parts from the result.
+Phase 3 replaces this wrapper with the real main-agent flow (task tool +
+child sessions), which is when progress becomes per-agent and per-tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from skene.analyzers.journey.models import Journey
+from skene.analyzers.journey.pipeline import JourneyPipelineConfig, run_journey_pipeline
+from skene.analyzers.journey.serialize import write as write_journey
+from skene.core.redact import redact_db_url
+from skene.core.sessions import SessionService
+from skene.core.store import now_ms
+from skene.llm.base import LLMClient
+from skene.output import status
+from skene.output_paths import DEFAULT_OUTPUT_DIR_NAME
+from skene.schema import (
+    ArtifactPart,
+    AssistantMessage,
+    JourneyAnalyseRequest,
+    MilestonePart,
+    Session,
+    TextPart,
+    ToolPart,
+    ToolStateCompleted,
+    ToolStateError,
+    ToolStateRunning,
+    UserMessage,
+    new_id,
+)
+
+JOURNEY_AGENT = "journey"
+_PIPELINE_TOOL = "journey_pipeline"
+
+
+@dataclass
+class JourneyRunHandle:
+    """Returned by :func:`start_journey_run`.
+
+    ``session`` identifies the run for HTTP clients; ``result`` resolves to
+    the validated Journey for in-process callers (the embedded CLI).
+    """
+
+    session: Session
+    result: "asyncio.Future[Journey]"
+
+
+class JourneyRequestError(ValueError):
+    """Invalid analyse request (bad paths / missing inputs)."""
+
+
+def _resolve_inputs(directory: str, request: JourneyAnalyseRequest) -> tuple[Path | None, Path | None, Path]:
+    """Validate the request against the workspace; returns (repo, schema_dir, output)."""
+    repo_root: Path | None = None
+    if request.path is not None:
+        repo_root = Path(request.path).expanduser().resolve()
+    elif request.schema_dir is None and request.db_url is None:
+        # Nothing specified at all: analyse the workspace directory itself.
+        repo_root = Path(directory)
+    if repo_root is not None and not repo_root.is_dir():
+        raise JourneyRequestError(f"path is not a directory: {repo_root}")
+
+    schema_dir: Path | None = None
+    if request.schema_dir is not None:
+        if request.db_url is not None:
+            raise JourneyRequestError("schemaDir and dbUrl are mutually exclusive")
+        schema_dir = Path(request.schema_dir).expanduser().resolve()
+        if not schema_dir.is_dir():
+            raise JourneyRequestError(f"schemaDir is not a directory: {schema_dir}")
+
+    if request.output is not None:
+        output = Path(request.output).expanduser().resolve()
+    else:
+        output = Path(directory) / DEFAULT_OUTPUT_DIR_NAME / "journey.yaml"
+    return repo_root, schema_dir, output
+
+
+def _describe_request(
+    product_name: str, repo_root: Path | None, schema_dir: Path | None, db_url: str | None, output: Path
+) -> str:
+    schema_display = str(schema_dir) if schema_dir else (redact_db_url(db_url) if db_url else "(none)")
+    return (
+        f"Analyse the user journey of {product_name}.\n"
+        f"Repo: {repo_root or '(none)'}\n"
+        f"Schema: {schema_display}\n"
+        f"Output: {output}"
+    )
+
+
+async def start_journey_run(
+    sessions: SessionService,
+    directory: str,
+    request: JourneyAnalyseRequest,
+    llm: LLMClient | None = None,
+) -> JourneyRunHandle:
+    """Create a session for the analysis and kick off the run.
+
+    Raises :class:`JourneyRequestError` before creating anything if the
+    request is invalid. ``llm`` overrides the service's factory (the
+    embedded CLI passes its already-configured client).
+    """
+    repo_root, schema_dir, output = _resolve_inputs(directory, request)
+    product_name = request.product_name or (repo_root or schema_dir or Path(directory)).name or "Product"
+    llm = llm or sessions.llm_factory()  # resolve before creating anything: no orphan session on missing credentials
+
+    session = await sessions.create_session(directory, agent=JOURNEY_AGENT, title=f"analyse-journey: {product_name}")
+    user_message = UserMessage(id=new_id("msg"), session_id=session.id, created=now_ms())
+    await sessions.emit_message(user_message)
+    await sessions.emit_part(
+        TextPart(
+            id=new_id("prt"),
+            session_id=session.id,
+            message_id=user_message.id,
+            text=_describe_request(product_name, repo_root, schema_dir, request.db_url, output),
+        )
+    )
+
+    result: asyncio.Future[Journey] = asyncio.get_running_loop().create_future()
+    sessions.start_run(
+        session,
+        _journey_run(
+            sessions,
+            session,
+            request,
+            llm,
+            repo_root=repo_root,
+            schema_dir=schema_dir,
+            output=output,
+            product_name=product_name,
+            result=result,
+        ),
+    )
+    return JourneyRunHandle(session=session, result=result)
+
+
+async def _journey_run(
+    sessions: SessionService,
+    session: Session,
+    request: JourneyAnalyseRequest,
+    llm: LLMClient,
+    *,
+    repo_root: Path | None,
+    schema_dir: Path | None,
+    output: Path,
+    product_name: str,
+    result: "asyncio.Future[Journey]",
+) -> None:
+    message = AssistantMessage(
+        id=new_id("msg"),
+        session_id=session.id,
+        created=now_ms(),
+        agent=JOURNEY_AGENT,
+        provider=llm.get_provider_name(),
+        model=llm.get_model_name(),
+    )
+    tool_part = ToolPart(
+        id=new_id("prt"),
+        session_id=session.id,
+        message_id=message.id,
+        tool=_PIPELINE_TOOL,
+        call_id=new_id("call"),
+        state=ToolStateRunning(
+            input={
+                "repo": str(repo_root) if repo_root else None,
+                "schemaDir": str(schema_dir) if schema_dir else None,
+                "dbUrl": redact_db_url(request.db_url) if request.db_url else None,
+                "productName": product_name,
+            },
+            title="journey pipeline",
+            started=now_ms(),
+        ),
+    )
+    try:
+        session = await sessions.set_status(session, "running")
+        await sessions.emit_message(message)
+        await sessions.emit_part(tool_part)
+
+        schema_index = None
+        if request.db_url is not None:
+            from skene.analyzers.schema_parsers.postgres_live import introspect_db
+
+            status(f"Introspecting database: {redact_db_url(request.db_url)}")
+            # Sync psycopg call inside the async server — keep it off the loop.
+            schema_index = await asyncio.to_thread(introspect_db, request.db_url)
+            status(f"Introspection complete: {sum(len(t) for t in schema_index.files.values())} tables found")
+
+        cfg = JourneyPipelineConfig(
+            repo_root=repo_root,
+            schema_dir=schema_dir,
+            schema_index=schema_index,
+            product_name=product_name,
+            classify_concurrency=request.classify_concurrency,
+            schema_max_turns=request.schema_max_turns,
+            code_max_turns=request.code_max_turns,
+            specialize=request.specialize,
+        )
+        journey = await run_journey_pipeline(cfg, llm)
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        write_journey(journey, output)
+
+        milestone_count = 0
+        for stage in journey.stages:
+            for milestone in stage.milestones:
+                milestone_count += 1
+                await sessions.emit_part(
+                    MilestonePart(
+                        id=new_id("prt"),
+                        session_id=session.id,
+                        message_id=message.id,
+                        milestone={"stage_id": stage.id, **milestone.model_dump(mode="json")},
+                    )
+                )
+        summary = f"Journey assembled: {len(journey.stages)} stages, {milestone_count} milestones."
+        await sessions.emit_part(
+            tool_part.model_copy(
+                update={
+                    "state": ToolStateCompleted(
+                        input=tool_part.state.input,
+                        output=summary,
+                        title="journey pipeline",
+                        started=tool_part.state.started,
+                        ended=now_ms(),
+                    )
+                }
+            ),
+            update=True,
+        )
+        await sessions.emit_part(
+            ArtifactPart(
+                id=new_id("prt"),
+                session_id=session.id,
+                message_id=message.id,
+                path=str(output),
+                title="journey.yaml",
+                summary=summary,
+            )
+        )
+        await sessions.emit_part(TextPart(id=new_id("prt"), session_id=session.id, message_id=message.id, text=summary))
+        await sessions.emit_message(message.model_copy(update={"finish": "completed"}), update=True)
+        await sessions.set_status(session, "idle")
+        result.set_result(journey)
+    except asyncio.CancelledError:
+        await sessions.emit_part(
+            tool_part.model_copy(
+                update={
+                    "state": ToolStateError(
+                        input=tool_part.state.input,
+                        error="aborted",
+                        started=tool_part.state.started,
+                        ended=now_ms(),
+                    )
+                }
+            ),
+            update=True,
+        )
+        await sessions.emit_message(message.model_copy(update={"finish": "aborted"}), update=True)
+        await sessions.set_status(session, "idle")
+        result.cancel()
+        raise
+    except Exception as e:  # noqa: BLE001 — surface pipeline failures as session state
+        await sessions.emit_part(
+            tool_part.model_copy(
+                update={
+                    "state": ToolStateError(
+                        input=tool_part.state.input,
+                        error=str(e),
+                        started=tool_part.state.started,
+                        ended=now_ms(),
+                    )
+                }
+            ),
+            update=True,
+        )
+        await sessions.emit_message(message.model_copy(update={"finish": "error", "error": str(e)}), update=True)
+        await sessions.set_status(session, "error", error=str(e))
+        result.set_exception(e)
+        # HTTP-triggered runs never await the handle; mark the exception
+        # retrieved so the event loop doesn't log a GC warning for it.
+        result.exception()

--- a/src/skene/core/redact.py
+++ b/src/skene/core/redact.py
@@ -1,0 +1,47 @@
+"""Secret redaction for anything that gets persisted or streamed.
+
+``db_url`` is deliberately never stored (see the design doc's watch-outs):
+sessions record only the display form produced here.
+"""
+
+from __future__ import annotations
+
+import re
+
+# scheme://user:password@  →  scheme://user:***@
+_DSN_CREDENTIALS = re.compile(r"(\w[\w+.-]*://[^:/?#@\s]+):[^@\s]+@")
+
+
+def redact_dsn_in_text(text: str) -> str:
+    """Redact the password of any ``scheme://user:pass@`` URL inside ``text``.
+
+    Safe on arbitrary prose: URLs without credentials pass through untouched.
+    """
+    return _DSN_CREDENTIALS.sub(r"\1:***@", text)
+
+
+def redact_db_url(url: str) -> str:
+    """Return a display-safe version of a DB URL with the password redacted.
+
+    Examples::
+
+        postgresql://user:secret@host:5432/mydb  →  postgresql://user:***@host:5432/mydb
+        postgresql://user@host/mydb              →  postgresql://user@host/mydb
+    """
+    try:
+        if "://" not in url:
+            return "<redacted>"
+
+        scheme, rest = url.split("://", 1)
+
+        if "@" in rest:
+            creds, remainder = rest.split("@", 1)
+            if ":" in creds and not creds.endswith(":"):
+                user = creds.split(":", 1)[0]
+                rest = f"{user}:***@{remainder}"
+            else:
+                rest = f"{creds}@{remainder}"
+
+        return f"{scheme}://{rest}"
+    except Exception:  # noqa: BLE001 — never let redaction leak by failing
+        return "<redacted>"

--- a/src/skene/core/services.py
+++ b/src/skene/core/services.py
@@ -1,0 +1,55 @@
+"""Wiring for the core services (store + bus + session service).
+
+Both entry points build this the same way: the HTTP server constructs it
+in its lifespan, the embedded CLI constructs it directly and calls core
+functions without a socket.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from skene.core.bus import Bus
+from skene.core.sessions import LLMFactory, SessionService
+from skene.core.store import DEFAULT_DB_PATH, Store
+
+
+def resolve_db_path(db_path: Path | str | None = None) -> Path:
+    """Explicit argument > ``SKENE_DB_PATH`` env > the global default."""
+    if db_path is not None:
+        return Path(db_path).expanduser()
+    env = os.environ.get("SKENE_DB_PATH")
+    if env:
+        return Path(env).expanduser()
+    return DEFAULT_DB_PATH
+
+
+def _no_llm_configured() -> "LLMFactory":
+    def factory():  # type: ignore[return-value]
+        raise RuntimeError(
+            "no LLM configured for this server — set provider credentials in .skene.config or SKENE_API_KEY"
+        )
+
+    return factory
+
+
+@dataclass
+class CoreServices:
+    store: Store
+    bus: Bus
+    sessions: SessionService
+
+    async def close(self) -> None:
+        await self.store.close()
+
+
+async def create_services(
+    db_path: Path | str | None = None,
+    llm_factory: LLMFactory | None = None,
+) -> CoreServices:
+    store = await Store.open(resolve_db_path(db_path))
+    bus = Bus()
+    sessions = SessionService(store, bus, llm_factory or _no_llm_configured())
+    return CoreServices(store=store, bus=bus, sessions=sessions)

--- a/src/skene/core/sessions.py
+++ b/src/skene/core/sessions.py
@@ -1,0 +1,294 @@
+"""Session lifecycle and the run coordinator.
+
+:class:`SessionService` owns the mapping from HTTP verbs to engine work:
+it creates sessions, starts prompt runs as background tasks, and cancels
+them on abort. The run coordinator (:meth:`SessionService.consume_stream`)
+is the phase-1 contract made concrete — it drains
+``LLMClient.run_agent_stream`` and turns loop events into persisted parts
+plus bus events, keeping the agent loop itself free of storage/HTTP
+concerns:
+
+    TurnStarted + AssistantText  → TextPart
+    ToolCallStarted              → ToolPart(state=running)
+    ToolCallFinished             → ToolPart(state=completed | error)
+    RunFinished                  → assistant message finish/tokens
+
+Phase 2 prompt runs are tool-less (the agent registry and task tool are
+phase 3); the coordinator is written against the stream shape, so phase 3
+reuses it unchanged for subagent runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, Callable, Coroutine
+from typing import Any
+
+from skene.core.bus import Bus
+from skene.core.redact import redact_dsn_in_text
+from skene.core.store import Store, UnknownSessionError, now_ms
+from skene.llm.agent_loop import (
+    AgentRunResult,
+    AgentStreamEvent,
+    AssistantText,
+    RunFinished,
+    ToolCallFinished,
+    ToolCallStarted,
+)
+from skene.llm.base import LLMClient
+from skene.output import debug, warning
+from skene.schema import (
+    AssistantMessage,
+    Message,
+    MessageCreated,
+    MessageUpdated,
+    Part,
+    PartCreated,
+    PartUpdated,
+    Session,
+    SessionCreated,
+    SessionError,
+    SessionIdle,
+    SessionUpdated,
+    TextPart,
+    TokenUsage,
+    ToolPart,
+    ToolStateCompleted,
+    ToolStateError,
+    ToolStateRunning,
+    UserMessage,
+    new_id,
+)
+
+# Phase 2 placeholder: prompt runs are plain chat. Phase 3 replaces this
+# with the agent registry's per-agent instructions + task tool.
+_CHAT_INSTRUCTIONS = (
+    "You are skene, a product-led-growth analysis assistant. Answer the "
+    "user's question directly and concisely. You have no tools available "
+    "in this session."
+)
+
+LLMFactory = Callable[[], LLMClient]
+
+
+class SessionBusyError(RuntimeError):
+    """Raised when a prompt arrives while the session is already running."""
+
+
+class _Run:
+    def __init__(self, task: asyncio.Task[None], abort: asyncio.Event) -> None:
+        self.task = task
+        self.abort = abort
+
+
+class SessionService:
+    def __init__(self, store: Store, bus: Bus, llm_factory: LLMFactory) -> None:
+        self.store = store
+        self.bus = bus
+        self.llm_factory = llm_factory
+        self._runs: dict[str, _Run] = {}
+
+    # -- creation / queries ---------------------------------------------------
+
+    async def create_session(
+        self,
+        directory: str,
+        *,
+        agent: str = "skene",
+        parent_id: str | None = None,
+        title: str | None = None,
+    ) -> Session:
+        project = await self.store.ensure_project(directory)
+        if parent_id is not None:
+            await self.store.get_session(parent_id)  # raises UnknownSessionError
+        session = await self.store.create_session(project_id=project.id, agent=agent, parent_id=parent_id, title=title)
+        self.bus.publish(SessionCreated(properties={"session": session}), directory=project.directory)
+        return session
+
+    def is_running(self, session_id: str) -> bool:
+        run = self._runs.get(session_id)
+        return run is not None and not run.task.done()
+
+    async def wait(self, session_id: str) -> None:
+        """Block until the session's active run (if any) finishes."""
+        run = self._runs.get(session_id)
+        if run is not None:
+            await asyncio.shield(run.task)
+
+    # -- prompt ---------------------------------------------------------------
+
+    async def prompt(self, session_id: str, text: str) -> UserMessage:
+        """Record the user message and start the run; returns immediately."""
+        session = await self.store.get_session(session_id)
+        if self.is_running(session_id):
+            raise SessionBusyError(session_id)
+
+        user_message = UserMessage(id=new_id("msg"), session_id=session.id, created=now_ms())
+        user_part = TextPart(
+            id=new_id("prt"),
+            session_id=session.id,
+            message_id=user_message.id,
+            text=redact_dsn_in_text(text),
+        )
+        await self.store.save_message(user_message)
+        await self.store.save_part(user_part)
+        directory = await self.store.session_directory(session.id)
+        self.bus.publish(MessageCreated(properties={"message": user_message}), directory=directory)
+        self.bus.publish(PartCreated(properties={"part": user_part}), directory=directory)
+
+        self.start_run(session, self._chat_run(session, text))
+        return user_message
+
+    def start_run(self, session: Session, coro: Coroutine[Any, Any, None]) -> None:
+        """Register ``coro`` as the session's active background run task."""
+        abort = asyncio.Event()
+        task = asyncio.create_task(coro, name=f"skene-run-{session.id}")
+        run = _Run(task, abort)
+        self._runs[session.id] = run
+
+        def _cleanup(_task: asyncio.Task[None]) -> None:
+            if self._runs.get(session.id) is run:
+                del self._runs[session.id]
+
+        task.add_done_callback(_cleanup)
+
+    async def abort(self, session_id: str) -> bool:
+        """Cooperatively stop, then cancel, the session's active run."""
+        await self.store.get_session(session_id)  # raises UnknownSessionError
+        run = self._runs.get(session_id)
+        if run is None or run.task.done():
+            return False
+        # Set the cooperative flag first (the loop checks it between turns),
+        # then cancel the task so in-flight provider calls don't linger.
+        run.abort.set()
+        run.task.cancel()
+        try:
+            await run.task
+        except asyncio.CancelledError:
+            pass
+        return True
+
+    def abort_event(self, session_id: str) -> asyncio.Event | None:
+        run = self._runs.get(session_id)
+        return run.abort if run is not None else None
+
+    # -- run coordinator -------------------------------------------------------
+
+    async def set_status(self, session: Session, status: str, *, error: str | None = None) -> Session:
+        session = await self.store.update_session(session.model_copy(update={"status": status}))
+        directory = await self.store.session_directory(session.id)
+        if status == "running":
+            self.bus.publish(SessionUpdated(properties={"session": session}), directory=directory)
+        elif status == "error":
+            self.bus.publish(SessionError(properties={"session": session, "error": error or ""}), directory=directory)
+        else:
+            self.bus.publish(SessionIdle(properties={"session": session}), directory=directory)
+        return session
+
+    async def emit_message(self, message: Message, *, update: bool = False) -> None:
+        await self.store.save_message(message)
+        directory = await self.store.session_directory(message.session_id)
+        event_cls = MessageUpdated if update else MessageCreated
+        self.bus.publish(event_cls(properties={"message": message}), directory=directory)
+
+    async def emit_part(self, part: Part, *, update: bool = False, delta: str | None = None) -> None:
+        await self.store.save_part(part)
+        directory = await self.store.session_directory(part.session_id)
+        event_cls = PartUpdated if update else PartCreated
+        self.bus.publish(event_cls(properties={"part": part, "delta": delta}), directory=directory)
+
+    async def consume_stream(
+        self,
+        session: Session,
+        message: AssistantMessage,
+        stream: AsyncGenerator[AgentStreamEvent, None],
+    ) -> AgentRunResult:
+        """Drain an agent stream into parts + events under ``message``.
+
+        Returns the final :class:`AgentRunResult`. The caller owns session
+        status transitions and the final message finish/usage update.
+        """
+        tool_parts: dict[str, ToolPart] = {}
+        result: AgentRunResult | None = None
+        async for event in stream:
+            if isinstance(event, AssistantText):
+                part = TextPart(id=new_id("prt"), session_id=session.id, message_id=message.id, text=event.text)
+                await self.emit_part(part, delta=event.text)
+            elif isinstance(event, ToolCallStarted):
+                part = ToolPart(
+                    id=new_id("prt"),
+                    session_id=session.id,
+                    message_id=message.id,
+                    tool=event.call.name,
+                    call_id=event.call.id,
+                    state=ToolStateRunning(input=_redact_inputs(event.call.arguments), started=now_ms()),
+                )
+                tool_parts[event.call.id] = part
+                await self.emit_part(part)
+            elif isinstance(event, ToolCallFinished):
+                part = tool_parts.get(event.call.id)
+                if part is None:  # defensive: finish without start
+                    warning(f"tool finish for unknown call {event.call.id}")
+                    continue
+                started = part.state.started if isinstance(part.state, ToolStateRunning) else None
+                inputs = _redact_inputs(event.call.arguments)
+                if event.error:
+                    state: ToolStateCompleted | ToolStateError = ToolStateError(
+                        input=inputs, error=event.result, started=started, ended=now_ms()
+                    )
+                else:
+                    state = ToolStateCompleted(input=inputs, output=event.result, started=started, ended=now_ms())
+                part = part.model_copy(update={"state": state})
+                tool_parts[event.call.id] = part
+                await self.emit_part(part, update=True)
+            elif isinstance(event, RunFinished):
+                result = event.result
+        if result is None:  # run_agent_stream guarantees RunFinished; be safe anyway
+            raise RuntimeError("agent stream ended without RunFinished")
+        return result
+
+    # -- the phase-2 chat run ---------------------------------------------------
+
+    async def _chat_run(self, session: Session, text: str) -> None:
+        message = AssistantMessage(id=new_id("msg"), session_id=session.id, created=now_ms(), agent=session.agent)
+        try:
+            session = await self.set_status(session, "running")
+            llm = self.llm_factory()
+            message = message.model_copy(update={"provider": llm.get_provider_name(), "model": llm.get_model_name()})
+            await self.emit_message(message)
+            abort = self.abort_event(session.id)
+            result = await self.consume_stream(
+                session,
+                message,
+                llm.run_agent_stream(instructions=_CHAT_INSTRUCTIONS, tools=[], initial_input=text, abort=abort),
+            )
+            usage = result.usage or {}
+            message = message.model_copy(
+                update={
+                    "finish": result.stopped_reason,
+                    "tokens": TokenUsage(input=usage.get("input_tokens", 0), output=usage.get("output_tokens", 0))
+                    if result.usage
+                    else None,
+                }
+            )
+            await self.emit_message(message, update=True)
+            await self.set_status(session, "idle")
+        except asyncio.CancelledError:
+            debug(f"run for session {session.id} cancelled")
+            message = message.model_copy(update={"finish": "aborted"})
+            await self.emit_message(message, update=True)
+            await self.set_status(session, "idle")
+            raise
+        except Exception as e:  # noqa: BLE001 — surface run failures as session state
+            warning(f"run for session {session.id} failed: {e}")
+            message = message.model_copy(update={"finish": "error", "error": str(e)})
+            await self.emit_message(message, update=True)
+            await self.set_status(session, "error", error=str(e))
+
+
+def _redact_inputs(arguments: dict) -> dict:
+    """Redact DSN credentials in string values before tool inputs hit disk/wire."""
+    return {k: redact_dsn_in_text(v) if isinstance(v, str) else v for k, v in arguments.items()}
+
+
+__all__ = ["SessionBusyError", "SessionService", "UnknownSessionError"]

--- a/src/skene/core/store.py
+++ b/src/skene/core/store.py
@@ -1,0 +1,260 @@
+"""SQLite persistence for sessions, messages, and parts.
+
+Plain relational state (the design doc's "take, simplified" verdict on
+opencode's persistence): every row stores the full wire-model JSON in a
+``data`` column plus the handful of columns queries filter on. Writers
+mutate state here and publish a bus event — there is no event-sourcing
+layer to replay.
+
+One global DB (default ``~/.local/share/skene/skene.db``, WAL mode) holds
+every workspace; rows are scoped through ``project.directory``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+from pydantic import TypeAdapter
+
+from skene.core.bus import normalize_directory
+from skene.schema import Message, Part, Project, Session, new_id
+
+DEFAULT_DB_PATH = Path("~/.local/share/skene/skene.db").expanduser()
+
+_MESSAGE_ADAPTER: TypeAdapter[Message] = TypeAdapter(Message)
+_PART_ADAPTER: TypeAdapter[Part] = TypeAdapter(Part)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project (
+    id        TEXT PRIMARY KEY,
+    directory TEXT NOT NULL UNIQUE,
+    name      TEXT,
+    created   INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS session (
+    id         TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES project(id),
+    parent_id  TEXT,
+    agent      TEXT NOT NULL,
+    title      TEXT,
+    status     TEXT NOT NULL,
+    created    INTEGER NOT NULL,
+    updated    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_session_project ON session(project_id, created);
+CREATE INDEX IF NOT EXISTS idx_session_parent  ON session(parent_id);
+CREATE TABLE IF NOT EXISTS message (
+    id         TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES session(id),
+    role       TEXT NOT NULL,
+    created    INTEGER NOT NULL,
+    data       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_message_session ON message(session_id, created);
+CREATE TABLE IF NOT EXISTS part (
+    id         TEXT PRIMARY KEY,
+    message_id TEXT NOT NULL REFERENCES message(id),
+    session_id TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    created    INTEGER NOT NULL,
+    data       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_part_message ON part(message_id, created);
+"""
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class UnknownSessionError(KeyError):
+    """Raised when a session id does not exist."""
+
+
+class Store:
+    """Async SQLite store. Create via :meth:`open`, dispose via :meth:`close`."""
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    @classmethod
+    async def open(cls, path: Path | str = DEFAULT_DB_PATH) -> "Store":
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(path)
+        db.row_factory = aiosqlite.Row
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA foreign_keys=ON")
+        await db.executescript(_SCHEMA)
+        await db.commit()
+        return cls(db)
+
+    async def close(self) -> None:
+        await self._db.close()
+
+    # -- projects -----------------------------------------------------------
+
+    async def ensure_project(self, directory: str | Path) -> Project:
+        """Get or create the project row for a workspace directory."""
+        directory = normalize_directory(directory)
+        async with self._db.execute("SELECT * FROM project WHERE directory = ?", (directory,)) as cur:
+            row = await cur.fetchone()
+        if row is not None:
+            return Project(id=row["id"], directory=row["directory"], name=row["name"])
+        project = Project(id=new_id("prj"), directory=directory, name=Path(directory).name or None)
+        await self._db.execute(
+            "INSERT INTO project (id, directory, name, created) VALUES (?, ?, ?, ?)",
+            (project.id, project.directory, project.name, now_ms()),
+        )
+        await self._db.commit()
+        return project
+
+    async def project_directory(self, project_id: str) -> str | None:
+        async with self._db.execute("SELECT directory FROM project WHERE id = ?", (project_id,)) as cur:
+            row = await cur.fetchone()
+        return row["directory"] if row else None
+
+    # -- sessions -----------------------------------------------------------
+
+    @staticmethod
+    def _session_from_row(row: aiosqlite.Row) -> Session:
+        return Session(
+            id=row["id"],
+            project_id=row["project_id"],
+            parent_id=row["parent_id"],
+            agent=row["agent"],
+            title=row["title"],
+            status=row["status"],
+            created=row["created"],
+            updated=row["updated"],
+        )
+
+    async def create_session(
+        self,
+        *,
+        project_id: str,
+        agent: str,
+        parent_id: str | None = None,
+        title: str | None = None,
+    ) -> Session:
+        ts = now_ms()
+        session = Session(
+            id=new_id("ses"),
+            project_id=project_id,
+            parent_id=parent_id,
+            agent=agent,
+            title=title,
+            status="idle",
+            created=ts,
+            updated=ts,
+        )
+        await self._db.execute(
+            "INSERT INTO session (id, project_id, parent_id, agent, title, status, created, updated)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                session.id,
+                session.project_id,
+                session.parent_id,
+                session.agent,
+                session.title,
+                session.status,
+                session.created,
+                session.updated,
+            ),
+        )
+        await self._db.commit()
+        return session
+
+    async def get_session(self, session_id: str) -> Session:
+        async with self._db.execute("SELECT * FROM session WHERE id = ?", (session_id,)) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise UnknownSessionError(session_id)
+        return self._session_from_row(row)
+
+    async def update_session(self, session: Session) -> Session:
+        session = session.model_copy(update={"updated": now_ms()})
+        await self._db.execute(
+            "UPDATE session SET title = ?, status = ?, updated = ? WHERE id = ?",
+            (session.title, session.status, session.updated, session.id),
+        )
+        await self._db.commit()
+        return session
+
+    async def list_sessions(self, *, project_id: str | None = None) -> list[Session]:
+        if project_id is None:
+            query, args = "SELECT * FROM session ORDER BY created", ()
+        else:
+            query, args = "SELECT * FROM session WHERE project_id = ? ORDER BY created", (project_id,)
+        async with self._db.execute(query, args) as cur:
+            rows = await cur.fetchall()
+        return [self._session_from_row(r) for r in rows]
+
+    async def list_children(self, parent_id: str) -> list[Session]:
+        async with self._db.execute("SELECT * FROM session WHERE parent_id = ? ORDER BY created", (parent_id,)) as cur:
+            rows = await cur.fetchall()
+        return [self._session_from_row(r) for r in rows]
+
+    async def session_directory(self, session_id: str) -> str:
+        """Workspace directory a session belongs to (for event scoping)."""
+        async with self._db.execute(
+            "SELECT p.directory FROM session s JOIN project p ON p.id = s.project_id WHERE s.id = ?",
+            (session_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise UnknownSessionError(session_id)
+        return row["directory"]
+
+    # -- messages & parts ----------------------------------------------------
+
+    async def save_message(self, message: Message) -> None:
+        """Insert or replace a message (updates rewrite the full JSON)."""
+        await self._db.execute(
+            "INSERT INTO message (id, session_id, role, created, data) VALUES (?, ?, ?, ?, ?)"
+            " ON CONFLICT(id) DO UPDATE SET data = excluded.data",
+            (message.id, message.session_id, message.role, message.created, message.model_dump_json()),
+        )
+        await self._db.commit()
+
+    async def save_part(self, part: Part) -> None:
+        """Insert or replace a part (tool-state transitions rewrite the JSON)."""
+        await self._db.execute(
+            "INSERT INTO part (id, message_id, session_id, type, created, data) VALUES (?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(id) DO UPDATE SET data = excluded.data",
+            (part.id, part.message_id, part.session_id, part.type, now_ms(), part.model_dump_json()),
+        )
+        await self._db.commit()
+
+    async def list_messages(self, session_id: str) -> list[tuple[Message, list[Part]]]:
+        """Messages in creation order, each with its parts in creation order."""
+        async with self._db.execute(
+            "SELECT data FROM message WHERE session_id = ? ORDER BY created, id", (session_id,)
+        ) as cur:
+            message_rows = await cur.fetchall()
+        async with self._db.execute(
+            "SELECT message_id, data FROM part WHERE session_id = ? ORDER BY created, id", (session_id,)
+        ) as cur:
+            part_rows = await cur.fetchall()
+
+        parts_by_message: dict[str, list[Part]] = {}
+        for row in part_rows:
+            parts_by_message.setdefault(row["message_id"], []).append(_PART_ADAPTER.validate_json(row["data"]))
+        result: list[tuple[Message, list[Part]]] = []
+        for row in message_rows:
+            message = _MESSAGE_ADAPTER.validate_json(row["data"])
+            result.append((message, parts_by_message.get(message.id, [])))
+        return result
+
+    # -- diagnostics ----------------------------------------------------------
+
+    async def counts(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for table in ("project", "session", "message", "part"):
+            async with self._db.execute(f"SELECT COUNT(*) AS n FROM {table}") as cur:  # noqa: S608
+                row = await cur.fetchone()
+            out[table] = row["n"]
+        return out

--- a/src/skene/schema/__init__.py
+++ b/src/skene/schema/__init__.py
@@ -42,6 +42,13 @@ from skene.schema.message import (
     ToolStateRunning,
     UserMessage,
 )
+from skene.schema.request import (
+    JourneyAnalyseAccepted,
+    JourneyAnalyseRequest,
+    MessageWithParts,
+    PromptRequest,
+    SessionCreateRequest,
+)
 from skene.schema.session import Project, Session, SessionStatus
 
 __all__ = [
@@ -50,18 +57,23 @@ __all__ = [
     "ArtifactPart",
     "AssistantMessage",
     "Event",
+    "JourneyAnalyseAccepted",
+    "JourneyAnalyseRequest",
     "Message",
     "MessageCreated",
     "MessageUpdated",
+    "MessageWithParts",
     "MilestonePart",
     "Part",
     "PartCreated",
     "PartUpdated",
     "Project",
+    "PromptRequest",
     "ReasoningPart",
     "ServerConnected",
     "ServerHeartbeat",
     "Session",
+    "SessionCreateRequest",
     "SessionCreated",
     "SessionError",
     "SessionIdle",

--- a/src/skene/schema/request.py
+++ b/src/skene/schema/request.py
@@ -1,0 +1,57 @@
+"""Request/response wire models for the HTTP API.
+
+These are the bodies clients send (and the small ack payloads they get
+back) — everything else on the wire lives in the sibling modules
+(``session``, ``message``, ``event``).
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from skene.schema.base import WireModel
+from skene.schema.message import Message, Part
+
+
+class SessionCreateRequest(WireModel):
+    agent: str = "skene"
+    parent_id: str | None = None
+    title: str | None = None
+
+
+class PromptRequest(WireModel):
+    """Body of ``POST /session/{id}/message``."""
+
+    text: str = Field(min_length=1)
+
+
+class MessageWithParts(WireModel):
+    """One message plus its parts, as returned by ``GET /session/{id}/message``."""
+
+    info: Message
+    parts: list[Part] = Field(default_factory=list)
+
+
+class JourneyAnalyseRequest(WireModel):
+    """Body of ``POST /journey/analyse`` — the v1-compat canned analysis.
+
+    Mirrors the ``skene analyse-journey`` CLI flags. ``db_url`` is used for
+    live introspection only and is never persisted or echoed back — the
+    stored session records a redacted display form.
+    """
+
+    path: str | None = None
+    schema_dir: str | None = None
+    db_url: str | None = None
+    product_name: str | None = None
+    output: str | None = None
+    schema_max_turns: int = Field(default=150, ge=1, le=500)
+    code_max_turns: int = Field(default=200, ge=1, le=500)
+    classify_concurrency: int = Field(default=8, ge=1, le=64)
+    specialize: bool = True
+
+
+class JourneyAnalyseAccepted(WireModel):
+    """Ack for ``POST /journey/analyse``: the run proceeds async in this session."""
+
+    session_id: str

--- a/src/skene/server/__init__.py
+++ b/src/skene/server/__init__.py
@@ -1,0 +1,9 @@
+"""FastAPI adapter over :mod:`skene.core`.
+
+HTTP/SSE only — no engine logic lives here. ``create_app`` in
+:mod:`skene.server.app` is the entry point.
+"""
+
+from skene.server.app import create_app
+
+__all__ = ["create_app"]

--- a/src/skene/server/app.py
+++ b/src/skene/server/app.py
@@ -1,0 +1,69 @@
+"""FastAPI application factory.
+
+Two construction modes:
+
+- ``create_app()`` — the ``skene serve`` path: services are built inside
+  the lifespan (so the store opens on uvicorn's event loop) and torn down
+  on shutdown.
+- ``create_app(services=...)`` — tests and embedded callers pass prebuilt
+  services and own their lifecycle; the lifespan does nothing.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import Depends, FastAPI
+
+from skene import __version__
+from skene.core.services import CoreServices, create_services
+from skene.core.sessions import LLMFactory
+from skene.server.deps import require_auth
+from skene.server.routes import event, journey, session
+
+
+def create_app(
+    services: CoreServices | None = None,
+    *,
+    db_path: Path | str | None = None,
+    llm_factory: LLMFactory | None = None,
+    auth_token: str | None = None,
+) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        owned = services is None
+        app.state.services = services if services is not None else await create_services(db_path, llm_factory)
+        try:
+            yield
+        finally:
+            if owned:
+                await app.state.services.close()
+
+    app = FastAPI(
+        title="skene",
+        version=__version__,
+        description="Backend server for the skene analysis engine.",
+        lifespan=lifespan,
+    )
+    app.state.auth_token = auth_token
+    if services is not None:
+        # Available before startup too, so in-process tests can skip the lifespan.
+        app.state.services = services
+
+    protected = [Depends(require_auth)]
+    app.include_router(session.router, dependencies=protected)
+    app.include_router(event.router, dependencies=protected)
+    app.include_router(journey.router, dependencies=protected)
+
+    @app.get("/health", tags=["meta"])
+    async def health() -> dict[str, str]:
+        return {"status": "ok", "version": __version__}
+
+    @app.get("/doc", tags=["meta"], include_in_schema=False)
+    async def doc() -> dict[str, Any]:
+        """The OpenAPI document (alias of ``/openapi.json``, per the design)."""
+        return app.openapi()
+
+    return app

--- a/src/skene/server/deps.py
+++ b/src/skene/server/deps.py
@@ -1,0 +1,44 @@
+"""Shared FastAPI dependencies: services access, workspace routing, auth."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, Request
+
+from skene.core.bus import normalize_directory
+from skene.core.services import CoreServices
+
+DIRECTORY_HEADER = "x-skene-directory"
+
+
+def get_services(request: Request) -> CoreServices:
+    return request.app.state.services
+
+
+def workspace_directory(
+    x_skene_directory: Annotated[str | None, Header()] = None,
+) -> str:
+    """Workspace a request operates on (opencode's per-request routing).
+
+    Falls back to the server's working directory when the header is absent.
+    """
+    raw = x_skene_directory or str(Path.cwd())
+    directory = normalize_directory(raw)
+    if not Path(directory).is_dir():
+        raise HTTPException(status_code=400, detail=f"{DIRECTORY_HEADER}: not a directory: {raw}")
+    return directory
+
+
+def require_auth(request: Request, authorization: Annotated[str | None, Header()] = None) -> None:
+    """Bearer-token check; a no-op when the server was started without a token."""
+    token = getattr(request.app.state, "auth_token", None)
+    if token is None:
+        return
+    if authorization != f"Bearer {token}":
+        raise HTTPException(status_code=401, detail="invalid or missing bearer token")
+
+
+Services = Annotated[CoreServices, Depends(get_services)]
+Directory = Annotated[str, Depends(workspace_directory)]

--- a/src/skene/server/routes/event.py
+++ b/src/skene/server/routes/event.py
@@ -1,0 +1,32 @@
+"""The ``GET /event`` SSE stream."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Header
+from fastapi.responses import StreamingResponse
+
+from skene.server.deps import Services
+from skene.server.sse import event_stream
+
+router = APIRouter(tags=["event"])
+
+
+@router.get("/event")
+async def events(
+    services: Services,
+    x_skene_directory: Annotated[str | None, Header()] = None,
+) -> StreamingResponse:
+    """Stream every bus event as SSE.
+
+    With an ``x-skene-directory`` header, only that workspace's events (plus
+    server-wide ones like heartbeats) are delivered; without it the stream
+    is unfiltered — unlike the REST routes, which fall back to the server
+    cwd, a global observer is the more useful default for an event tap.
+    """
+    return StreamingResponse(
+        event_stream(services.bus, x_skene_directory),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )

--- a/src/skene/server/routes/journey.py
+++ b/src/skene/server/routes/journey.py
@@ -1,0 +1,47 @@
+"""The v1-compat journey routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastapi import APIRouter, HTTPException
+
+from skene.core.journey import JourneyRequestError, start_journey_run
+from skene.output_paths import BUNDLE_DIR_NAMES
+from skene.schema import JourneyAnalyseAccepted, JourneyAnalyseRequest
+from skene.server.deps import Directory, Services
+
+router = APIRouter(tags=["journey"])
+
+
+@router.post("/journey/analyse", response_model=JourneyAnalyseAccepted, status_code=202)
+async def analyse(body: JourneyAnalyseRequest, services: Services, directory: Directory) -> JourneyAnalyseAccepted:
+    """Start the canned journey analysis in a fresh session.
+
+    The run proceeds async: watch ``/event`` for progress; the result lands
+    as an ``artifact`` part (and as ``journey.yaml`` in the workspace).
+    """
+    try:
+        handle = await start_journey_run(services.sessions, directory, body)
+    except JourneyRequestError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except RuntimeError as e:
+        # The llm_factory refused (no credentials): fail fast instead of
+        # creating a session doomed to error.
+        raise HTTPException(status_code=503, detail=str(e)) from e
+    return JourneyAnalyseAccepted(session_id=handle.session.id)
+
+
+@router.get("/journey")
+async def get_journey(directory: Directory) -> dict[str, Any]:
+    """Latest ``journey.yaml`` for the workspace, parsed to JSON."""
+    for bundle in BUNDLE_DIR_NAMES:
+        path = Path(directory) / bundle / "journey.yaml"
+        if path.is_file():
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+            raise HTTPException(status_code=500, detail=f"unparseable journey.yaml at {path}")
+    raise HTTPException(status_code=404, detail="no journey.yaml in this workspace — run /journey/analyse first")

--- a/src/skene/server/routes/session.py
+++ b/src/skene/server/routes/session.py
@@ -1,0 +1,81 @@
+"""Session CRUD, prompting, and abort."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from skene.core.sessions import SessionBusyError
+from skene.core.store import UnknownSessionError
+from skene.schema import (
+    Message,
+    MessageWithParts,
+    PromptRequest,
+    Session,
+    SessionCreateRequest,
+)
+from skene.server.deps import Directory, Services
+
+router = APIRouter(tags=["session"])
+
+
+@router.post("/session", response_model=Session, status_code=201)
+async def create_session(body: SessionCreateRequest, services: Services, directory: Directory) -> Session:
+    try:
+        return await services.sessions.create_session(
+            directory, agent=body.agent, parent_id=body.parent_id, title=body.title
+        )
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown parent session: {e.args[0]}") from e
+
+
+@router.get("/session", response_model=list[Session])
+async def list_sessions(services: Services, directory: Directory) -> list[Session]:
+    project = await services.store.ensure_project(directory)
+    return await services.store.list_sessions(project_id=project.id)
+
+
+@router.get("/session/{session_id}", response_model=Session)
+async def get_session(session_id: str, services: Services) -> Session:
+    try:
+        return await services.store.get_session(session_id)
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
+
+
+@router.get("/session/{session_id}/children", response_model=list[Session])
+async def list_children(session_id: str, services: Services) -> list[Session]:
+    try:
+        await services.store.get_session(session_id)
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
+    return await services.store.list_children(session_id)
+
+
+@router.get("/session/{session_id}/message", response_model=list[MessageWithParts])
+async def list_messages(session_id: str, services: Services) -> list[MessageWithParts]:
+    try:
+        await services.store.get_session(session_id)
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
+    messages = await services.store.list_messages(session_id)
+    return [MessageWithParts(info=message, parts=parts) for message, parts in messages]
+
+
+@router.post("/session/{session_id}/message", response_model=Message, status_code=202)
+async def prompt(session_id: str, body: PromptRequest, services: Services) -> Message:
+    """Record the user message and start the run; progress streams on ``/event``."""
+    try:
+        return await services.sessions.prompt(session_id, body.text)
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
+    except SessionBusyError as e:
+        raise HTTPException(status_code=409, detail="session already has a run in progress") from e
+
+
+@router.post("/session/{session_id}/abort")
+async def abort(session_id: str, services: Services) -> dict[str, bool]:
+    try:
+        aborted = await services.sessions.abort(session_id)
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
+    return {"aborted": aborted}

--- a/src/skene/server/sse.py
+++ b/src/skene/server/sse.py
@@ -1,0 +1,36 @@
+"""Server-sent-events encoding for the ``/event`` stream."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from skene.core.bus import Bus
+from skene.schema import Event, ServerConnected, ServerHeartbeat
+
+HEARTBEAT_SECONDS = 10.0
+
+
+def encode(event: Event) -> str:
+    """One SSE frame: the event's wire JSON in a ``data:`` line."""
+    return f"data: {event.model_dump_json()}\n\n"
+
+
+async def event_stream(
+    bus: Bus,
+    directory: str | None,
+    heartbeat_seconds: float = HEARTBEAT_SECONDS,
+) -> AsyncGenerator[str, None]:
+    """Subscribe to the bus and yield SSE frames until the client goes away.
+
+    Opens with ``server.connected`` and emits ``server.heartbeat`` after
+    every ``heartbeat_seconds`` of silence so proxies keep the connection
+    alive (opencode's semantics).
+    """
+    subscription = bus.subscribe(directory)
+    try:
+        yield encode(ServerConnected())
+        while True:
+            event = await subscription.get(timeout=heartbeat_seconds)
+            yield encode(event if event is not None else ServerHeartbeat())
+    finally:
+        subscription.close()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,77 @@
+"""Shared test doubles for core/server tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any, AsyncGenerator
+
+from skene.analyzers.journey.models import Evidence, Journey, Milestone, Product, Stage
+from skene.llm.agent_loop import AssistantTurn, Message, Tool
+from skene.llm.base import LLMClient
+
+
+class ScriptedClient(LLMClient):
+    """Returns a queued AssistantTurn per ``generate_with_tools`` call."""
+
+    def __init__(self, turns: list[AssistantTurn]) -> None:
+        self._turns = list(turns)
+
+    async def generate_content_with_usage(self, prompt: str) -> tuple[str, dict[str, int] | None]:
+        raise NotImplementedError
+
+    async def generate_content_stream(self, prompt: str) -> AsyncGenerator[str, None]:
+        if False:
+            yield ""
+        raise NotImplementedError
+
+    def get_model_name(self) -> str:
+        return "scripted-model"
+
+    def get_provider_name(self) -> str:
+        return "scripted"
+
+    async def generate_with_tools(self, messages: list[Message], tools: list[Tool]) -> AssistantTurn:
+        if not self._turns:
+            raise AssertionError("scripted client ran out of turns")
+        return self._turns.pop(0)
+
+
+class HangingClient(ScriptedClient):
+    """Blocks forever on the first LLM call — for abort/busy tests."""
+
+    def __init__(self) -> None:
+        super().__init__([])
+        self.called = asyncio.Event()
+
+    async def generate_with_tools(self, messages: list[Message], tools: list[Tool]) -> AssistantTurn:
+        self.called.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+def make_journey(product: str = "TestProduct") -> Journey:
+    """Smallest Journey the models accept: one stage, one milestone."""
+    return Journey(
+        product=Product(name=product, generated_at=datetime.now(UTC)),
+        stages=[
+            Stage(
+                id="onboarding",
+                order=1,
+                name="Onboarding",
+                milestones=[
+                    Milestone(
+                        id="signs_up",
+                        order=1,
+                        name="User signs up",
+                        description="Creates an account",
+                        evidence=[Evidence(source="code", reason="signup route", path="auth/signup.ts")],
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def turn(text: str | None = None, tool_calls: list | None = None, usage: dict[str, int] | None = None) -> Any:
+    return AssistantTurn(text=text, tool_calls=tool_calls or [], usage=usage)

--- a/tests/test_core/conftest.py
+++ b/tests/test_core/conftest.py
@@ -1,0 +1,26 @@
+"""Fixtures for core-service tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skene.core.services import CoreServices, create_services
+
+
+@pytest.fixture
+async def services(tmp_path: Path) -> CoreServices:
+    def _no_llm():
+        raise AssertionError("test did not configure an LLM client")
+
+    built = await create_services(tmp_path / "skene.db", llm_factory=_no_llm)
+    yield built
+    await built.close()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    directory = tmp_path / "workspace"
+    directory.mkdir()
+    return directory

--- a/tests/test_core/test_bus.py
+++ b/tests/test_core/test_bus.py
@@ -1,0 +1,65 @@
+"""Tests for the in-process event bus."""
+
+from __future__ import annotations
+
+import asyncio
+
+from skene.core.bus import Bus, normalize_directory
+from skene.schema import ServerHeartbeat
+
+
+async def test_publish_reaches_subscriber():
+    bus = Bus()
+    sub = bus.subscribe()
+    event = ServerHeartbeat()
+    bus.publish(event)
+    assert await sub.get(timeout=1) is event
+
+
+async def test_directory_filtering():
+    bus = Bus()
+    watcher_a = bus.subscribe("/tmp/a")
+    watcher_all = bus.subscribe()
+
+    scoped = ServerHeartbeat()
+    bus.publish(scoped, directory="/tmp/b")
+    # The /tmp/a watcher must not see /tmp/b's event; the unfiltered one must.
+    assert await watcher_all.get(timeout=1) is scoped
+    assert await watcher_a.get(timeout=0.05) is None
+
+    matching = ServerHeartbeat()
+    bus.publish(matching, directory="/tmp/a")
+    assert await watcher_a.get(timeout=1) is matching
+
+    server_wide = ServerHeartbeat()
+    bus.publish(server_wide)  # no directory → everyone
+    assert await watcher_a.get(timeout=1) is server_wide
+    assert await watcher_all.get(timeout=1) is matching  # queued earlier
+
+
+async def test_directory_comparison_is_normalized(tmp_path):
+    bus = Bus()
+    sub = bus.subscribe(tmp_path)
+    event = ServerHeartbeat()
+    # Publish with a non-canonical spelling of the same directory.
+    bus.publish(event, directory=str(tmp_path) + "/.")
+    assert await sub.get(timeout=1) is event
+    assert sub.directory == normalize_directory(tmp_path)
+
+
+async def test_close_stops_iteration():
+    bus = Bus()
+    sub = bus.subscribe()
+
+    async def consume():
+        return [e async for e in sub]
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    event = ServerHeartbeat()
+    bus.publish(event)
+    sub.close()
+    assert await asyncio.wait_for(task, timeout=1) == [event]
+    # After close, publishes don't reach the subscription.
+    bus.publish(ServerHeartbeat())
+    assert sub._queue.qsize() == 0

--- a/tests/test_core/test_journey_run.py
+++ b/tests/test_core/test_journey_run.py
@@ -1,0 +1,143 @@
+"""Tests for the canned journey run (session wrapper around the pipeline)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import yaml
+
+import skene.core.journey as journey_module
+from skene.core.embedded import run_journey_embedded
+from skene.core.journey import JourneyRequestError, start_journey_run
+from skene.schema import (
+    ArtifactPart,
+    JourneyAnalyseRequest,
+    MilestonePart,
+    ToolPart,
+)
+from tests.fakes import ScriptedClient, make_journey
+
+
+@pytest.fixture
+def fake_pipeline(monkeypatch):
+    """Replace the real (LLM-driven) pipeline with an instant fake."""
+    calls = []
+
+    async def fake(cfg, llm):
+        calls.append(cfg)
+        return make_journey()
+
+    monkeypatch.setattr(journey_module, "run_journey_pipeline", fake)
+    return calls
+
+
+async def test_journey_run_emits_parts_and_artifact(services, workspace, fake_pipeline):
+    request = JourneyAnalyseRequest(path=str(workspace))
+    handle = await start_journey_run(services.sessions, str(workspace), request, llm=ScriptedClient([]))
+    journey = await asyncio.wait_for(handle.result, timeout=5)
+    await services.sessions.wait(handle.session.id)
+
+    assert journey.product.name == "TestProduct"
+    output = workspace / "skene-context" / "journey.yaml"
+    assert output.is_file()
+    assert yaml.safe_load(output.read_text())["product"]["name"] == "TestProduct"
+
+    session = await services.store.get_session(handle.session.id)
+    assert session.status == "idle"
+    assert session.agent == "journey"
+
+    messages = await services.store.list_messages(session.id)
+    assert [type(m).__name__ for m, _ in messages] == ["UserMessage", "AssistantMessage"]
+    assistant, parts = messages[1]
+    assert assistant.finish == "completed"
+
+    tool_parts = [p for p in parts if isinstance(p, ToolPart)]
+    assert len(tool_parts) == 1
+    assert tool_parts[0].state.status == "completed"
+
+    milestones = [p for p in parts if isinstance(p, MilestonePart)]
+    assert len(milestones) == 1
+    assert milestones[0].milestone["stage_id"] == "onboarding"
+    assert milestones[0].milestone["id"] == "signs_up"
+
+    artifacts = [p for p in parts if isinstance(p, ArtifactPart)]
+    assert len(artifacts) == 1
+    assert artifacts[0].path == str(output)
+
+    # Config passed through to the pipeline.
+    (cfg,) = fake_pipeline
+    assert cfg.repo_root == workspace.resolve()
+    assert cfg.product_name == workspace.name
+
+
+async def test_journey_run_records_pipeline_failure(services, workspace, monkeypatch):
+    async def explode(cfg, llm):
+        raise RuntimeError("pipeline exploded")
+
+    monkeypatch.setattr(journey_module, "run_journey_pipeline", explode)
+    handle = await start_journey_run(
+        services.sessions, str(workspace), JourneyAnalyseRequest(path=str(workspace)), llm=ScriptedClient([])
+    )
+    with pytest.raises(RuntimeError, match="pipeline exploded"):
+        await asyncio.wait_for(handle.result, timeout=5)
+    await services.sessions.wait(handle.session.id)
+
+    session = await services.store.get_session(handle.session.id)
+    assert session.status == "error"
+    assistant, parts = (await services.store.list_messages(session.id))[-1]
+    assert assistant.finish == "error"
+    tool_part = next(p for p in parts if isinstance(p, ToolPart))
+    assert tool_part.state.status == "error"
+    assert "pipeline exploded" in tool_part.state.error
+
+
+async def test_journey_request_validation(services, workspace):
+    with pytest.raises(JourneyRequestError, match="not a directory"):
+        await start_journey_run(
+            services.sessions,
+            str(workspace),
+            JourneyAnalyseRequest(path=str(workspace / "missing")),
+            llm=ScriptedClient([]),
+        )
+    with pytest.raises(JourneyRequestError, match="mutually exclusive"):
+        await start_journey_run(
+            services.sessions,
+            str(workspace),
+            JourneyAnalyseRequest(schema_dir=str(workspace), db_url="postgresql://u:p@h/db"),
+            llm=ScriptedClient([]),
+        )
+
+
+async def test_journey_user_prompt_never_contains_db_password(services, workspace, fake_pipeline, monkeypatch):
+    monkeypatch.setattr(journey_module.asyncio, "to_thread", lambda fn, *a: _fake_index())
+    request = JourneyAnalyseRequest(path=str(workspace), db_url="postgresql://user:hunter2@db:5432/app")
+    handle = await start_journey_run(services.sessions, str(workspace), request, llm=ScriptedClient([]))
+    await asyncio.wait_for(handle.result, timeout=5)
+    await services.sessions.wait(handle.session.id)
+
+    for message, parts in await services.store.list_messages(handle.session.id):
+        for part in parts:
+            assert "hunter2" not in part.model_dump_json()
+
+
+async def _fake_index():
+    from skene.analyzers.schema_parsers.models import SchemaIndex
+
+    return SchemaIndex(files={})
+
+
+async def test_embedded_runner_round_trip(workspace, tmp_path, monkeypatch):
+    async def fake(cfg, llm):
+        return make_journey()
+
+    monkeypatch.setattr(journey_module, "run_journey_pipeline", fake)
+    output = tmp_path / "out" / "journey.yaml"
+    journey = await run_journey_embedded(
+        JourneyAnalyseRequest(path=str(workspace), output=str(output)),
+        ScriptedClient([]),
+        directory=workspace,
+        db_path=tmp_path / "embedded.db",
+    )
+    assert journey.product.name == "TestProduct"
+    assert output.is_file()

--- a/tests/test_core/test_sessions.py
+++ b/tests/test_core/test_sessions.py
@@ -1,0 +1,162 @@
+"""Tests for the session service and run coordinator."""
+
+from __future__ import annotations
+
+import pytest
+
+from skene.core.sessions import SessionBusyError
+from skene.llm.agent_loop import ToolCall
+from skene.schema import (
+    AssistantMessage,
+    PartCreated,
+    PartUpdated,
+    SessionCreated,
+    TextPart,
+    ToolPart,
+    UserMessage,
+)
+from tests.fakes import HangingClient, ScriptedClient, turn
+
+
+async def test_create_session_publishes_event(services, workspace):
+    sub = services.bus.subscribe(workspace)
+    session = await services.sessions.create_session(str(workspace), title="hello")
+    assert session.agent == "skene"
+    event = await sub.get(timeout=1)
+    assert isinstance(event, SessionCreated)
+    assert event.properties.session.id == session.id
+
+
+async def test_prompt_runs_chat_to_idle(services, workspace):
+    services.sessions.llm_factory = lambda: ScriptedClient(
+        [
+            turn(
+                text="thinking",
+                tool_calls=[ToolCall(id="c1", name="ghost", arguments={"x": 1})],
+                usage={"input_tokens": 10, "output_tokens": 5},
+            ),
+            turn(text="done", usage={"input_tokens": 20, "output_tokens": 7}),
+        ]
+    )
+    session = await services.sessions.create_session(str(workspace))
+    sub = services.bus.subscribe(workspace)
+
+    user_message = await services.sessions.prompt(session.id, "hi")
+    assert isinstance(user_message, UserMessage)
+    await services.sessions.wait(session.id)
+
+    assert (await services.store.get_session(session.id)).status == "idle"
+
+    messages = await services.store.list_messages(session.id)
+    assert [type(m).__name__ for m, _ in messages] == ["UserMessage", "AssistantMessage"]
+    assistant, parts = messages[1]
+    assert isinstance(assistant, AssistantMessage)
+    assert assistant.finish == "no_tool_calls"
+    assert assistant.provider == "scripted"
+    assert assistant.tokens.input == 30 and assistant.tokens.output == 12
+    # thinking text, the (unknown) tool call, final text — in stream order.
+    assert [type(p).__name__ for p in parts] == ["TextPart", "ToolPart", "TextPart"]
+    tool_part = parts[1]
+    assert isinstance(tool_part, ToolPart)
+    assert tool_part.state.status == "error"  # unknown tool surfaces as tool error
+    assert tool_part.state.input == {"x": 1}
+
+    events = []
+    while (event := await sub.get(timeout=0.05)) is not None:
+        events.append(type(event).__name__)
+    assert events[0] == "MessageCreated"  # the user message
+    assert "PartUpdated" in events  # tool state transition
+    assert events[-1] == "SessionIdle"
+
+
+async def test_prompt_while_running_raises_busy(services, workspace):
+    client = HangingClient()
+    services.sessions.llm_factory = lambda: client
+    session = await services.sessions.create_session(str(workspace))
+    await services.sessions.prompt(session.id, "first")
+    await client.called.wait()
+    with pytest.raises(SessionBusyError):
+        await services.sessions.prompt(session.id, "second")
+    await services.sessions.abort(session.id)
+
+
+async def test_abort_marks_run_aborted(services, workspace):
+    client = HangingClient()
+    services.sessions.llm_factory = lambda: client
+    session = await services.sessions.create_session(str(workspace))
+    await services.sessions.prompt(session.id, "hi")
+    await client.called.wait()
+
+    assert (await services.store.get_session(session.id)).status == "running"
+    assert await services.sessions.abort(session.id) is True
+    assert (await services.store.get_session(session.id)).status == "idle"
+    assistant = (await services.store.list_messages(session.id))[-1][0]
+    assert assistant.finish == "aborted"
+    # A second abort is a no-op.
+    assert await services.sessions.abort(session.id) is False
+
+
+async def test_llm_failure_marks_session_error(services, workspace):
+    def broken_factory():
+        raise RuntimeError("no credentials")
+
+    services.sessions.llm_factory = broken_factory
+    session = await services.sessions.create_session(str(workspace))
+    await services.sessions.prompt(session.id, "hi")
+    await services.sessions.wait(session.id)
+
+    assert (await services.store.get_session(session.id)).status == "error"
+    assistant = (await services.store.list_messages(session.id))[-1][0]
+    assert assistant.finish == "error"
+    assert "no credentials" in assistant.error
+
+
+async def test_user_prompt_text_is_dsn_redacted(services, workspace):
+    services.sessions.llm_factory = lambda: ScriptedClient([turn(text="ok")])
+    session = await services.sessions.create_session(str(workspace))
+    await services.sessions.prompt(session.id, "analyse postgresql://user:secret@db:5432/app please")
+    await services.sessions.wait(session.id)
+    (_, user_parts), *_ = await services.store.list_messages(session.id)
+    assert isinstance(user_parts[0], TextPart)
+    assert "secret" not in user_parts[0].text
+    assert "postgresql://user:***@db:5432/app" in user_parts[0].text
+
+
+async def test_stream_events_are_scoped_to_directory(services, workspace, tmp_path):
+    other = tmp_path / "other"
+    other.mkdir()
+    services.sessions.llm_factory = lambda: ScriptedClient([turn(text="ok")])
+    session = await services.sessions.create_session(str(workspace))
+    outsider = services.bus.subscribe(other)
+    await services.sessions.prompt(session.id, "hi")
+    await services.sessions.wait(session.id)
+    assert await outsider.get(timeout=0.05) is None
+
+
+def _event_names(events: list) -> list[str]:
+    return [type(e).__name__ for e in events]
+
+
+async def test_part_created_and_updated_shapes(services, workspace):
+    services.sessions.llm_factory = lambda: ScriptedClient(
+        [turn(tool_calls=[ToolCall(id="c1", name="ghost", arguments={})]), turn(text="done")]
+    )
+    session = await services.sessions.create_session(str(workspace))
+    sub = services.bus.subscribe(workspace)
+    await services.sessions.prompt(session.id, "go")
+    await services.sessions.wait(session.id)
+
+    created = []
+    updated = []
+    while (event := await sub.get(timeout=0.05)) is not None:
+        if isinstance(event, PartCreated):
+            created.append(event.properties.part)
+        elif isinstance(event, PartUpdated):
+            updated.append(event.properties.part)
+    # ToolPart created running, then updated to a terminal state, same part id.
+    tool_created = [p for p in created if isinstance(p, ToolPart)]
+    tool_updated = [p for p in updated if isinstance(p, ToolPart)]
+    assert len(tool_created) == 1 and len(tool_updated) == 1
+    assert tool_created[0].id == tool_updated[0].id
+    assert tool_created[0].state.status == "running"
+    assert tool_updated[0].state.status == "error"

--- a/tests/test_core/test_store.py
+++ b/tests/test_core/test_store.py
@@ -1,0 +1,91 @@
+"""Round-trip tests for the SQLite store."""
+
+from __future__ import annotations
+
+import pytest
+
+from skene.core.store import UnknownSessionError, now_ms
+from skene.schema import (
+    AssistantMessage,
+    TextPart,
+    ToolPart,
+    ToolStateCompleted,
+    UserMessage,
+    new_id,
+)
+
+
+async def test_ensure_project_is_idempotent(services, workspace):
+    first = await services.store.ensure_project(workspace)
+    second = await services.store.ensure_project(workspace)
+    assert first.id == second.id
+    assert first.directory == str(workspace.resolve())
+    assert first.name == workspace.name
+
+
+async def test_session_crud(services, workspace):
+    project = await services.store.ensure_project(workspace)
+    session = await services.store.create_session(project_id=project.id, agent="skene", title="t")
+    assert session.status == "idle"
+
+    fetched = await services.store.get_session(session.id)
+    assert fetched == session
+
+    updated = await services.store.update_session(session.model_copy(update={"status": "running"}))
+    assert updated.status == "running"
+    assert updated.updated >= session.updated
+    assert (await services.store.get_session(session.id)).status == "running"
+
+    child = await services.store.create_session(project_id=project.id, agent="code", parent_id=session.id)
+    assert [s.id for s in await services.store.list_children(session.id)] == [child.id]
+    assert [s.id for s in await services.store.list_sessions(project_id=project.id)] == [session.id, child.id]
+    assert await services.store.session_directory(session.id) == project.directory
+
+    with pytest.raises(UnknownSessionError):
+        await services.store.get_session("ses_nope")
+    with pytest.raises(UnknownSessionError):
+        await services.store.session_directory("ses_nope")
+
+
+async def test_message_and_part_round_trip(services, workspace):
+    project = await services.store.ensure_project(workspace)
+    session = await services.store.create_session(project_id=project.id, agent="skene")
+
+    user = UserMessage(id=new_id("msg"), session_id=session.id, created=now_ms())
+    assistant = AssistantMessage(id=new_id("msg"), session_id=session.id, created=now_ms(), agent="skene")
+    await services.store.save_message(user)
+    await services.store.save_message(assistant)
+
+    text = TextPart(id=new_id("prt"), session_id=session.id, message_id=user.id, text="hello")
+    tool = ToolPart(
+        id=new_id("prt"),
+        session_id=session.id,
+        message_id=assistant.id,
+        tool="echo",
+        call_id="c1",
+        state=ToolStateCompleted(input={"text": "hi"}, output="hi"),
+    )
+    await services.store.save_part(text)
+    await services.store.save_part(tool)
+
+    messages = await services.store.list_messages(session.id)
+    assert [(m.id, [p.id for p in parts]) for m, parts in messages] == [
+        (user.id, [text.id]),
+        (assistant.id, [tool.id]),
+    ]
+    # Discriminated unions reconstruct to the exact subtype.
+    restored = messages[1][1][0]
+    assert isinstance(restored, ToolPart)
+    assert restored.state == ToolStateCompleted(input={"text": "hi"}, output="hi")
+
+    # save_part is an upsert: state transitions rewrite the row.
+    await services.store.save_part(tool.model_copy(update={"state": ToolStateCompleted(output="bye")}))
+    messages = await services.store.list_messages(session.id)
+    assert messages[1][1][0].state.output == "bye"
+
+
+async def test_counts(services, workspace):
+    project = await services.store.ensure_project(workspace)
+    await services.store.create_session(project_id=project.id, agent="skene")
+    counts = await services.store.counts()
+    assert counts == {"project": 1, "session": 1, "message": 0, "part": 0}

--- a/tests/test_server/conftest.py
+++ b/tests/test_server/conftest.py
@@ -1,0 +1,41 @@
+"""Fixtures for HTTP API tests (ASGI in-process, no socket)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from skene.core.services import CoreServices, create_services
+from skene.server import create_app
+
+
+@pytest.fixture
+async def services(tmp_path: Path) -> CoreServices:
+    def _no_llm():
+        raise AssertionError("test did not configure an LLM client")
+
+    built = await create_services(tmp_path / "skene.db", llm_factory=_no_llm)
+    yield built
+    await built.close()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    directory = tmp_path / "workspace"
+    directory.mkdir()
+    return directory
+
+
+@pytest.fixture
+def app(services):
+    return create_app(services)
+
+
+@pytest.fixture
+async def client(app, workspace):
+    transport = httpx.ASGITransport(app=app)
+    headers = {"x-skene-directory": str(workspace)}
+    async with httpx.AsyncClient(transport=transport, base_url="http://skene.test", headers=headers) as c:
+        yield c

--- a/tests/test_server/test_api.py
+++ b/tests/test_server/test_api.py
@@ -1,0 +1,171 @@
+"""End-to-end tests for the HTTP API (in-process ASGI)."""
+
+from __future__ import annotations
+
+import httpx
+import yaml
+
+from skene.server import create_app
+from tests.fakes import HangingClient, ScriptedClient, turn
+
+
+async def test_health(client):
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+async def test_doc_serves_openapi(client):
+    response = await client.get("/doc")
+    assert response.status_code == 200
+    assert "/session/{session_id}/message" in response.json()["paths"]
+
+
+async def test_session_crud_and_wire_shape(client):
+    created = await client.post("/session", json={"title": "hello", "agent": "skene"})
+    assert created.status_code == 201
+    session = created.json()
+    # camelCase on the wire.
+    assert session["projectId"].startswith("prj_")
+    assert session["id"].startswith("ses_")
+    assert session["status"] == "idle"
+    assert session["parentId"] is None
+
+    listed = await client.get("/session")
+    assert [s["id"] for s in listed.json()] == [session["id"]]
+
+    fetched = await client.get(f"/session/{session['id']}")
+    assert fetched.json() == session
+
+    assert (await client.get("/session/ses_nope")).status_code == 404
+
+    child = await client.post("/session", json={"parentId": session["id"], "agent": "code"})
+    assert child.status_code == 201
+    children = await client.get(f"/session/{session['id']}/children")
+    assert [s["id"] for s in children.json()] == [child.json()["id"]]
+
+    orphan = await client.post("/session", json={"parentId": "ses_nope"})
+    assert orphan.status_code == 404
+
+
+async def test_unknown_body_field_is_rejected(client):
+    # WireModel extra="forbid": typos fail loudly instead of being dropped.
+    response = await client.post("/session", json={"tittle": "typo"})
+    assert response.status_code == 422
+
+
+async def test_sessions_are_scoped_by_directory_header(client, tmp_path):
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    await client.post("/session", json={})
+    scoped = await client.get("/session", headers={"x-skene-directory": str(other)})
+    assert scoped.json() == []
+    missing = await client.get("/session", headers={"x-skene-directory": str(other / "nope")})
+    assert missing.status_code == 400
+
+
+async def test_prompt_flow(client, services):
+    services.sessions.llm_factory = lambda: ScriptedClient(
+        [turn(text="hi there", usage={"input_tokens": 3, "output_tokens": 2})]
+    )
+    session_id = (await client.post("/session", json={})).json()["id"]
+
+    accepted = await client.post(f"/session/{session_id}/message", json={"text": "hello"})
+    assert accepted.status_code == 202
+    assert accepted.json()["role"] == "user"
+
+    await services.sessions.wait(session_id)
+
+    messages = (await client.get(f"/session/{session_id}/message")).json()
+    assert [m["info"]["role"] for m in messages] == ["user", "assistant"]
+    assistant = messages[1]
+    assert assistant["info"]["finish"] == "no_tool_calls"
+    assert assistant["info"]["tokens"] == {"input": 3, "output": 2}
+    assert assistant["parts"][0]["type"] == "text"
+    assert assistant["parts"][0]["text"] == "hi there"
+
+    assert (await client.post("/session/ses_nope/message", json={"text": "x"})).status_code == 404
+    assert (await client.get("/session/ses_nope/message")).status_code == 404
+
+
+async def test_prompt_busy_and_abort(client, services):
+    hanging = HangingClient()
+    services.sessions.llm_factory = lambda: hanging
+    session_id = (await client.post("/session", json={})).json()["id"]
+
+    assert (await client.post(f"/session/{session_id}/message", json={"text": "one"})).status_code == 202
+    await hanging.called.wait()
+    assert (await client.post(f"/session/{session_id}/message", json={"text": "two"})).status_code == 409
+
+    aborted = await client.post(f"/session/{session_id}/abort")
+    assert aborted.json() == {"aborted": True}
+    assert (await client.get(f"/session/{session_id}")).json()["status"] == "idle"
+    assert (await client.post(f"/session/{session_id}/abort")).json() == {"aborted": False}
+    assert (await client.post("/session/ses_nope/abort")).status_code == 404
+
+
+async def test_journey_analyse_validates_request(client, workspace):
+    bad = await client.post("/journey/analyse", json={"path": str(workspace / "missing")})
+    assert bad.status_code == 400
+    both = await client.post("/journey/analyse", json={"schemaDir": str(workspace), "dbUrl": "postgresql://u:p@h/db"})
+    assert both.status_code == 400
+
+
+async def test_journey_analyse_starts_session(client, services, workspace, monkeypatch):
+    import skene.core.journey as journey_module
+    from tests.fakes import make_journey
+
+    async def fake(cfg, llm):
+        return make_journey()
+
+    monkeypatch.setattr(journey_module, "run_journey_pipeline", fake)
+    services.sessions.llm_factory = lambda: ScriptedClient([])
+
+    accepted = await client.post("/journey/analyse", json={"path": str(workspace)})
+    assert accepted.status_code == 202
+    session_id = accepted.json()["sessionId"]
+    await services.sessions.wait(session_id)
+
+    session = (await client.get(f"/session/{session_id}")).json()
+    assert session["status"] == "idle"
+    assert session["agent"] == "journey"
+
+    journey = await client.get("/journey")
+    assert journey.status_code == 200
+    assert journey.json()["product"]["name"] == "TestProduct"
+
+
+async def test_get_journey_404_when_absent(client):
+    assert (await client.get("/journey")).status_code == 404
+
+
+async def test_get_journey_reads_existing_yaml(client, workspace):
+    bundle = workspace / "skene-context"
+    bundle.mkdir()
+    (bundle / "journey.yaml").write_text(yaml.safe_dump({"product": {"name": "P"}}))
+    response = await client.get("/journey")
+    assert response.json()["product"]["name"] == "P"
+
+
+async def test_bearer_auth(services, workspace):
+    app = create_app(services, auth_token="sekrit")
+    transport = httpx.ASGITransport(app=app)
+    headers = {"x-skene-directory": str(workspace)}
+    async with httpx.AsyncClient(transport=transport, base_url="http://skene.test", headers=headers) as client:
+        assert (await client.get("/session")).status_code == 401
+        assert (await client.get("/session", headers={"Authorization": "Bearer wrong"})).status_code == 401
+        ok = await client.get("/session", headers={"Authorization": "Bearer sekrit"})
+        assert ok.status_code == 200
+        # /health stays open for probes.
+        assert (await client.get("/health")).status_code == 200
+
+
+async def test_journey_analyse_503_when_no_llm_configured(client, services, workspace):
+    def broken_factory():
+        raise RuntimeError("no LLM configured")
+
+    services.sessions.llm_factory = broken_factory
+    response = await client.post("/journey/analyse", json={"path": str(workspace)})
+    assert response.status_code == 503
+    # Failing fast means no orphan session was created.
+    assert (await client.get("/session")).json() == []

--- a/tests/test_server/test_sse.py
+++ b/tests/test_server/test_sse.py
@@ -1,0 +1,128 @@
+"""Tests for the /event SSE stream."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from skene.core.bus import Bus
+from skene.schema import ServerHeartbeat
+from skene.server.sse import event_stream
+from tests.fakes import ScriptedClient, turn
+
+
+def _parse(frame: str) -> dict:
+    assert frame.startswith("data: ") and frame.endswith("\n\n")
+    return json.loads(frame[len("data: ") :])
+
+
+async def test_stream_opens_with_connected_then_delivers_events():
+    bus = Bus()
+    stream = event_stream(bus, directory=None)
+    connected = _parse(await anext(stream))
+    assert connected["type"] == "server.connected"
+    assert connected["id"].startswith("evt_")
+
+    bus.publish(ServerHeartbeat())
+    event = _parse(await asyncio.wait_for(anext(stream), timeout=1))
+    assert event["type"] == "server.heartbeat"
+    await stream.aclose()
+
+
+async def test_stream_emits_heartbeat_on_idle():
+    bus = Bus()
+    stream = event_stream(bus, directory=None, heartbeat_seconds=0.05)
+    await anext(stream)  # server.connected
+    event = _parse(await asyncio.wait_for(anext(stream), timeout=1))
+    assert event["type"] == "server.heartbeat"
+    await stream.aclose()
+
+
+async def test_stream_filters_by_directory(tmp_path):
+    mine = tmp_path / "mine"
+    mine.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+
+    bus = Bus()
+    stream = event_stream(bus, directory=str(mine), heartbeat_seconds=0.05)
+    await anext(stream)  # server.connected
+
+    scoped = ServerHeartbeat()
+    bus.publish(scoped, directory=str(other))
+    # The other workspace's event must not arrive — next frame is an idle heartbeat.
+    event = _parse(await asyncio.wait_for(anext(stream), timeout=1))
+    assert event["id"] != scoped.id
+    await stream.aclose()
+
+
+async def test_http_event_route_streams(app, client, services, workspace):
+    """Full loop: prompt a session and watch its events arrive over HTTP SSE.
+
+    httpx's ASGITransport buffers whole responses, which deadlocks on an
+    endless SSE body — so this test speaks raw ASGI to the app for the
+    stream and uses the normal client for the mutating calls.
+    """
+    services.sessions.llm_factory = lambda: ScriptedClient([turn(text="hi")])
+
+    types: list[str] = []
+    headers_seen: dict[bytes, bytes] = {}
+    saw_idle = asyncio.Event()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/event",
+        "raw_path": b"/event",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"x-skene-directory", str(workspace).encode())],
+        "client": ("test", 123),
+        "server": ("skene.test", 80),
+    }
+
+    async def receive():
+        # Simulate the client hanging up once we've seen the run finish.
+        await saw_idle.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            headers_seen.update(dict(message["headers"]))
+        elif message["type"] == "http.response.body":
+            for line in message.get("body", b"").decode().splitlines():
+                if not line.startswith("data: "):
+                    continue
+                event = json.loads(line[len("data: ") :])
+                types.append(event["type"])
+                if event["type"] == "session.idle":
+                    saw_idle.set()
+
+    stream_task = asyncio.create_task(app(scope, receive, send))
+    while "server.connected" not in types:  # wait for the subscription to exist
+        await asyncio.sleep(0.01)
+
+    session_id = (await client.post("/session", json={})).json()["id"]
+    await client.post(f"/session/{session_id}/message", json={"text": "hello"})
+    await asyncio.wait_for(stream_task, timeout=5)
+
+    assert headers_seen[b"content-type"].startswith(b"text/event-stream")
+    assert types[0] == "server.connected"
+    assert "session.created" in types
+    assert "message.created" in types
+    assert "part.created" in types
+    assert types[-1] == "session.idle"
+
+
+async def test_event_route_rejects_bad_auth(services, workspace):
+    import httpx
+
+    from skene.server import create_app
+
+    app = create_app(services, auth_token="sekrit")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://skene.test") as client:
+        assert (await client.get("/event")).status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,24 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -297,6 +315,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.139.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -1045,8 +1079,10 @@ version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "aiosqlite" },
     { name = "anthropic" },
     { name = "click" },
+    { name = "fastapi" },
     { name = "google-genai" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -1061,6 +1097,7 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-typescript" },
     { name = "typer" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -1078,8 +1115,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.0" },
+    { name = "aiosqlite", specifier = ">=0.20" },
     { name = "anthropic", specifier = ">=0.40" },
     { name = "click", specifier = ">=8.0" },
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.0" },
@@ -1095,6 +1134,7 @@ requires-dist = [
     { name = "tree-sitter-javascript", specifier = ">=0.23" },
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["ui"]
 
@@ -1121,6 +1161,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/64/89299aefc6ebdf4fc899f5dc14c7fcb7eb9da9290a2b4d615ae7ab884b17/sqlglot-30.8.0.tar.gz", hash = "sha256:1c5f93fb742dd9aaa75eee6bb33a637794a858b9a86375fac23a2dc0f7bc127e", size = 5869750, upload-time = "2026-05-13T09:04:38.923Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/4e/80705091aaf9c95e125d243f0aa871bc9f3670b4c9d963e6bad3b3dce8ff/sqlglot-30.8.0-py3-none-any.whl", hash = "sha256:af903378c331d5b72277a1b41118f07bc3e50cf4478e2d47eed12c96ee6a22a4", size = 687831, upload-time = "2026-05-13T09:04:36.336Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -1263,6 +1316,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.50.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/f6/cc9aadc0e481344a42095d222bfa764122fb8cfba708d1922917bd8bfb01/uvicorn-0.50.2.tar.gz", hash = "sha256:b92bf03509b82bcb9d49e7335b4fd364518ad021c2dc18b4e6a2fec8c955a0bb", size = 93716, upload-time = "2026-07-06T10:38:31.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/f0/7c228ee10c7ab8fd3a21d06579a6f7c6075c6ce72594a20fb5d2f206ff24/uvicorn-0.50.2-py3-none-any.whl", hash = "sha256:4ae72a385630bcc17a0adb8290f26c993865e0b43a2114c2aab96420172c056a", size = 72846, upload-time = "2026-07-06T10:38:30.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 2 of [docs/design/backend-server.md](https://github.com/SkeneTechnologies/skene/blob/feat/server-phase2/docs/design/backend-server.md): the server MVP, built on phase 1's wire schema and streaming agent loop (#95).

## What's in here

**`skene/core`** — domain services, no HTTP:
- `bus.py`: in-process pub/sub; events publish with an optional workspace `directory`, subscribers with a filter receive matching + server-wide events
- `store.py`: aiosqlite store (WAL, one global DB at `~/.local/share/skene/skene.db`, `SKENE_DB_PATH` override) — projects/sessions/messages/parts, full wire JSON per row plus query columns
- `sessions.py`: `SessionService` with the **run coordinator** — drains `run_agent_stream` into persisted parts + bus events per the phase-1 mapping (`AssistantText` → `TextPart`, `ToolCallStarted` → `ToolPart(running)`, `ToolCallFinished` → `completed`/`error`); abort sets the cooperative event *and* cancels the task
- `journey.py`: the canned analysis as a session — wraps the **untouched** deterministic pipeline, emits a `journey_pipeline` tool part plus milestone/artifact/summary parts; live-DB introspection via `asyncio.to_thread`; `db_url` never persisted (DSN redaction in `redact.py`)
- `embedded.py`: in-process entry point for the CLI (no socket)

**`skene/server`** — FastAPI adapter:
- session CRUD / prompt / abort, `/event` SSE (10s heartbeat, `x-skene-directory` filtering), `POST /journey/analyse` + `GET /journey` compat routes, `/health`, `/doc`
- optional bearer auth; camelCase wire shapes straight from `skene/schema` (new request models in `schema/request.py`)

**CLI**:
- new `skene serve [--port 4906] [--host] [--token]` — binds 127.0.0.1 by default, refuses non-local binds without a token
- `skene analyse-journey` now runs through the embedded core: identical UX, but every run persists an inspectable session trace

## Deliberate phase-2 scope cuts
- `POST /session/{id}/message` runs a tool-less placeholder chat — the agent registry + task tool replace it in phase 3 (same coordinator)
- `GET /agent`, `GET /provider`, `GET/PATCH /config` deferred (registry is phase 3, config surface phase 5)
- Journey progress is coarse (one tool part) — per-agent/per-tool granularity arrives naturally with phase 3's child sessions

The design doc's phase table is updated and a "Phase 2 — as built" section records the contracts phase 3 builds on (child-session plumbing, abort fan-out being phase 3's job, the `MilestonePart` shape decision, single-run-per-session, global `llm_factory`).

## Test plan
- 39 new tests: `tests/test_core` (bus, store, session/run coordinator, journey run) and `tests/test_server` (API + SSE; SSE spoken over raw ASGI since httpx's `ASGITransport` buffers whole responses)
- full suite: 474 passed; `ruff check` + `ruff format --check` clean
- manual smoke: booted `skene serve`, exercised `/health`, session create/list, SSE `server.connected`, journey-route validation errors, and the non-local-bind token guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)