### PR TITLE
feat: server hardening & growth (phase 5)

### DIFF
--- a/docs/design/backend-server.md
+++ b/docs/design/backend-server.md
@@ -1,6 +1,6 @@
 # Skene Backend Server — Design
 
-Status: in progress (2026-07-06) — phases 1-4 implemented, phase 5 pending.
+Status: implemented (2026-07-07) — phases 1-5 done.
 Work lands on feature branches targeting the `v1.0` integration branch.
 
 | Phase | Status | Where |
@@ -9,7 +9,7 @@ Work lands on feature branches targeting the `v1.0` integration branch.
 | 2. Server MVP | **done** | `feat/server-phase2` |
 | 3. Agentic flow | **done** | `feat/server-phase3` |
 | 4. TUI cutover | **done** | `feat/server-phase4` |
-| 5. Hardening & growth | pending | |
+| 5. Hardening & growth | **done** | `feat/server-phase5` |
 
 Goal: turn skene into a client/server system where a **main skene agent** orchestrates
 **code/db subagents** (and future ones), and CLI + TUI are thin clients of a single
@@ -158,9 +158,11 @@ POST /session/{id}/message                   prompt: returns user Message immedi
 POST /session/{id}/abort                     cancel the running task tree
 POST /session/{id}/permissions/{permID}      answer an ask (phase 2)
 
+GET  /session/{id}/permissions               asks the session has raised
 GET  /agent                                  registry (primary + subagents)
 GET  /provider                               available providers/models
-GET  /config          PATCH /config          resolved config (secrets redacted)
+GET  /config                                 resolved config (secrets redacted;
+                                             read-only — no PATCH, see phase 5)
 
 POST /journey/analyse                        v1-compat convenience: creates a session,
                                              sends the canned analyse prompt, returns
@@ -660,6 +662,75 @@ hooks into the as-built system:
   `skene sessions prune` only if the DB becomes a problem; the durable
   event log / event sourcing stays out until a multi-writer or sync
   requirement shows up.
+
+### Phase 5 — as built
+
+What landed in `feat/server-phase5`, and the contracts future work builds
+on:
+
+- **Permission ask flow is live end-to-end, with no built-in consumer
+  yet.** `skene/schema/permission.py` (`PermissionRequest`,
+  `PermissionAnswer`), `permission.asked`/`permission.answered` in the
+  `Event` union, a `permission_request` table (upserts, like parts), and
+  `core/permissions.py::PermissionService`. A tool handler calls
+  `await permissions.ask(session_id, tool=..., title=..., metadata=...)`
+  → the request persists as `pending`, `permission.asked` hits the bus,
+  and the handler suspends until `POST /session/{id}/permissions/{permID}`
+  (body `{reply: "allow"|"deny"}`) resolves it — `ask` returns the
+  boolean. Semantics chosen deliberately: **no rulesets** (every ask goes
+  to the client), **no timeout** (pending until answered or aborted),
+  **one-shot answers** (second answer → 409), and an aborted run records
+  its pending asks as `denied` (shielded, so clients never see a dangling
+  prompt). Answers to asks whose waiter is gone (server restart) still
+  record. Tools reach the service by closure —
+  `JourneyRunContext.permissions` is threaded from `create_services`
+  through `make_run_factory`/`start_journey_run` — the agent loop itself
+  stays permission-free. The built-in journey tools are read-only, so
+  nothing asks today; the first db-write tool should. Client side: the
+  TUI's `sse.go` decodes both events (regen done), but there is **no ask
+  UI yet** — build it against `permission.asked` when a tool that asks
+  ships. `GET /session/{id}/permissions` lists a session's asks.
+- **Config/provider surface, read-only by decision.** `GET /config`
+  returns `ServerConfigInfo` (provider, model, base_url,
+  `apiKeyConfigured` boolean — never the key), `GET /provider` the
+  supported-provider catalog with `active` marking the running one.
+  The snapshot is built by `skene serve` at startup and passed through
+  `create_app(config_info=...)` → `CoreServices.config_info`; bare
+  setups (tests, embedded CLI) get nulls + version. **There is no
+  PATCH**: the phase-5 pointer said pick deliberately, and rebuilding
+  `llm_factory` mid-flight while runs are in progress buys nothing —
+  changing config means restarting `skene serve`.
+- **Per-agent model overrides work through the factory signature.**
+  `SessionService.resolve_llm(model)` passes `model=` to any
+  `llm_factory` that accepts that keyword (inspected per call, since
+  tests swap factories); zero-arg factories ignore overrides with a
+  debug note. `execute_run` gained a `model` param; the task tool
+  resolves a fresh client for a subagent whose `AgentDef.model` is set
+  (otherwise the child shares the parent's client), and
+  `start_journey_run` honours the primary's. `skene serve`'s factory
+  accepts the keyword; the embedded CLI's pinned client deliberately
+  does not (one CLI invocation = one client).
+- **Remote serving: `skene attach <url> [--token]`.** Verifies
+  `/health`, then persists `server_url`/`server_token` into
+  `.skene.config` (project config if present, else user config;
+  `--clear` detaches). Once attached — or with `--server` /
+  `SKENE_SERVER_URL` — `analyse-journey` runs remotely via
+  `cli/remote.py::run_journey_remote`: subscribes to `/event` *before*
+  POSTing `/journey/analyse` (the TUI's race-avoidance pattern), folds
+  the stream into the same `status()` lines the embedded run prints,
+  waits for `session.idle`/`session.error`, and returns the artifact
+  part. Request paths are interpreted on the **server's** filesystem
+  (documented in the flag help). Ctrl-C aborts the remote session tree
+  on a fresh connection. No local LLM credentials are needed in remote
+  mode. The Python SSE reader mirrors the Go one (`data:`-only frames,
+  16 MiB cap); testing it needs a real socket — `tests/test_server/
+  test_remote.py` boots uvicorn on a loopback port because
+  `ASGITransport` buffers (the phase-2 note strikes again).
+- **Still deferred, still deliberate:** true token streaming (provider
+  layer), porting the TUI's legacy uvx commands server-side, the TUI
+  ask UI and journey-inputs form, a CI job regenerating the Go client /
+  diffing `openapi.json` (regen is still `make -C tui generate`), and
+  the durable event log.
 
 ---
 

--- a/src/skene/cli/app.py
+++ b/src/skene/cli/app.py
@@ -271,6 +271,7 @@ def skene_growth_entry():
 from skene.cli.commands import (  # noqa: E402, F401
     analyse_journey,
     analyze,
+    attach,
     build,
     config_cmd,
     login,

--- a/src/skene/cli/commands/analyse_journey.py
+++ b/src/skene/cli/commands/analyse_journey.py
@@ -135,6 +135,22 @@ def analyse_journey_cmd(
         "--no-fallback",
         help="Disable model fallback on rate limits; retry same model instead",
     ),
+    server: str | None = typer.Option(
+        None,
+        "--server",
+        envvar="SKENE_SERVER_URL",
+        help=(
+            "Run the analysis on a remote skene server instead of locally "
+            "(default: the server stored by `skene attach`, if any). Paths "
+            "are interpreted on the server's filesystem."
+        ),
+    ),
+    server_token: str | None = typer.Option(
+        None,
+        "--server-token",
+        envvar="SKENE_SERVER_TOKEN",
+        help="Bearer token for --server (default: the token stored by `skene attach`).",
+    ),
     auto_publish: bool = typer.Option(
         False,
         "--auto-publish",
@@ -201,6 +217,27 @@ def analyse_journey_cmd(
         quiet=quiet,
         debug=debug,
     )
+
+    # Attached to a server (via `skene attach` or --server)? Run remotely —
+    # the server holds the LLM credentials, so none are needed locally.
+    server_url = server or rc.config.get("server_url")
+    if server_url:
+        _run_remote(
+            server_url,
+            server_token or rc.config.get("server_token"),
+            config_root=config_root,
+            base_path=base_path,
+            schema_path=schema_path,
+            db_url=db_url,
+            output=output,
+            product_name=product_name,
+            schema_max_turns=schema_max_turns,
+            code_max_turns=code_max_turns,
+            classify_concurrency=classify_concurrency,
+            specialize=not no_specialize,
+        )
+        return
+
     resolved_api_key = require_llm_credentials(rc, "analyse-journey")
 
     journey_path = resolve_artifact_path(output, "journey.yaml")
@@ -250,6 +287,59 @@ def analyse_journey_cmd(
     _render_summary(journey_path, journey)
 
     _maybe_auto_publish(rc, config_root, journey_path=journey_path, enabled=auto_publish)
+
+
+def _run_remote(
+    server_url: str,
+    server_token: str | None,
+    *,
+    config_root: Path,
+    base_path: Path | None,
+    schema_path: Path | None,
+    db_url: str | None,
+    output: Path,
+    product_name: str | None,
+    schema_max_turns: int,
+    code_max_turns: int,
+    classify_concurrency: int,
+    specialize: bool,
+) -> None:
+    """Drive the analysis on an attached server; paths are server-side."""
+    import asyncio
+
+    from skene.cli.remote import RemoteServerError, check_health, run_journey_remote
+
+    try:
+        check_health(server_url, server_token)
+    except RemoteServerError as e:
+        error(f"{e}\n(re-run `skene attach <url>` or `skene attach --clear` to run locally)")
+        raise typer.Exit(1) from e
+
+    request = JourneyAnalyseRequest(
+        path=str(base_path) if base_path is not None else None,
+        schema_dir=str(schema_path) if schema_path is not None else None,
+        db_url=db_url,
+        product_name=product_name,
+        output=str(output) if output != Path(f"{DEFAULT_OUTPUT_DIR}/journey.yaml") else None,
+        classify_concurrency=classify_concurrency,
+        schema_max_turns=schema_max_turns,
+        code_max_turns=code_max_turns,
+        specialize=specialize,
+    )
+    console.print(f"[bold]skene · analyse-journey[/bold] [dim]→ remote server {server_url}[/dim]")
+    try:
+        artifact = asyncio.run(run_journey_remote(server_url, server_token, str(config_root), request))
+    except KeyboardInterrupt:
+        error("aborted")
+        raise typer.Exit(130) from None
+    except RemoteServerError as e:
+        error(f"analysis failed: {e}")
+        raise typer.Exit(1) from e
+
+    summary = artifact.get("summary") or ""
+    if summary:
+        console.print(summary)
+    console.print(f"\n[green]✓[/green] wrote {artifact.get('path')} (on {server_url})")
 
 
 def _maybe_auto_publish(rc, project_root: Path, *, journey_path: Path, enabled: bool) -> None:

--- a/src/skene/cli/commands/attach.py
+++ b/src/skene/cli/commands/attach.py
@@ -1,0 +1,98 @@
+"""Attach the CLI to a remote skene server (``skene attach``).
+
+Thin by design (see the phase-5 notes in docs/design/backend-server.md):
+verifies the server is reachable and persists ``server_url`` /
+``server_token`` in ``.skene.config``, after which ``analyse-journey``
+drives that server over HTTP instead of running embedded. ``--clear``
+detaches.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import typer
+
+from skene.cli.app import app
+from skene.output import console, error, success
+
+
+def _config_path_for_write() -> Path:
+    """The project config if present, else the user config (created if needed)."""
+    from skene.config import find_project_config, find_user_config
+
+    project = find_project_config()
+    if project is not None:
+        return project
+    user = find_user_config()
+    if user is not None:
+        return user
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_dir = Path(config_home) / "skene" if config_home else Path.home() / ".config" / "skene"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir / "config"
+
+
+def _upsert_config_keys(path: Path, values: dict[str, str | None]) -> None:
+    """Set (or with None, remove) top-level string keys in a TOML config file."""
+    lines = path.read_text().splitlines() if path.exists() else ["# skene configuration"]
+    for key, value in values.items():
+        pattern = re.compile(rf"^\s*{re.escape(key)}\s*=")
+        lines = [line for line in lines if not pattern.match(line)]
+        if value is not None:
+            lines.append(f'{key} = "{value}"')
+    path.write_text("\n".join(lines) + "\n")
+    if os.name != "nt":
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+
+
+@app.command(name="attach", rich_help_panel="manage")
+def attach_cmd(
+    url: str | None = typer.Argument(None, help="Base URL of a running skene server (e.g. http://127.0.0.1:4906)"),
+    token: str | None = typer.Option(
+        None,
+        "--token",
+        envvar="SKENE_SERVER_TOKEN",
+        help="Bearer token the server was started with (required for non-local servers).",
+    ),
+    clear: bool = typer.Option(False, "--clear", help="Detach: remove the stored server URL and token."),
+) -> None:
+    """
+    Attach this machine's skene CLI to a running skene server.
+
+    Verifies the server responds on /health, then stores its URL (and
+    token, if given) in .skene.config. Once attached, ``analyse-journey``
+    sends runs to that server instead of executing locally. Detach with
+    ``skene attach --clear``.
+    """
+    from skene.cli.remote import RemoteServerError, check_health
+
+    config_path = _config_path_for_write()
+
+    if clear:
+        if url is not None:
+            error("--clear takes no URL")
+            raise typer.Exit(2)
+        _upsert_config_keys(config_path, {"server_url": None, "server_token": None})
+        success(f"detached (updated {config_path})")
+        return
+
+    if url is None:
+        error("missing server URL (or use --clear to detach)")
+        raise typer.Exit(2)
+
+    url = url.rstrip("/")
+    try:
+        payload = check_health(url, token)
+    except RemoteServerError as e:
+        error(str(e))
+        raise typer.Exit(1) from e
+
+    _upsert_config_keys(config_path, {"server_url": url, "server_token": token})
+    console.print(f"[dim]server version: {payload.get('version', '?')}[/dim]")
+    success(f"attached to {url} (stored in {config_path})")

--- a/src/skene/cli/commands/serve.py
+++ b/src/skene/cli/commands/serve.py
@@ -58,13 +58,26 @@ def serve_cmd(
         api_key=api_key, provider=provider, model=model, base_url=base_url, quiet=quiet, debug=debug
     )
 
-    def llm_factory():
+    def llm_factory(model: str | None = None):
+        """``model`` is the per-agent override (AgentDef.model); None = the configured model."""
+        from dataclasses import replace
+
         from skene.cli._journey_runner import build_llm
 
         if not rc.api_key and not rc.is_local:
             raise RuntimeError("no LLM credentials configured — restart the server with --api-key or set SKENE_API_KEY")
-        return build_llm(rc, rc.api_key or rc.provider, no_fallback=False)
+        resolved = rc if model is None else replace(rc, model=model)
+        return build_llm(resolved, rc.api_key or rc.provider, no_fallback=False)
 
-    server_app = create_app(db_path=db_path, llm_factory=llm_factory, auth_token=token)
+    from skene.schema import ServerConfigInfo
+
+    config_info = ServerConfigInfo(
+        version="",  # filled in by the route
+        provider=rc.provider,
+        model=rc.model,
+        base_url=rc.base_url,
+        api_key_configured=bool(rc.api_key),
+    )
+    server_app = create_app(db_path=db_path, llm_factory=llm_factory, auth_token=token, config_info=config_info)
     console.print(f"[bold]skene[/bold] server listening on http://{host}:{port} (provider: {rc.provider})")
     uvicorn.run(server_app, host=host, port=port, log_level="debug" if debug else "info")

--- a/src/skene/cli/remote.py
+++ b/src/skene/cli/remote.py
@@ -1,0 +1,227 @@
+"""HTTP client for driving a remote skene server (``skene attach``).
+
+The embedded path (:mod:`skene.core.embedded`) calls core services
+in-process; this module is its remote twin — the same canned journey run
+driven over HTTP + SSE against a server started elsewhere. Kept
+deliberately small: one health probe and one journey runner. Progress
+rendering folds the event stream into the same ``status()`` lines the
+embedded run prints.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+
+from skene.output import status, warning
+from skene.schema import JourneyAnalyseRequest
+
+DIRECTORY_HEADER = "x-skene-directory"
+
+# One frame larger than this indicates a broken stream (mirrors the TUI cap).
+_MAX_EVENT_SIZE = 16 * 1024 * 1024
+
+
+class RemoteServerError(RuntimeError):
+    """The remote server is unreachable, unauthorized, or rejected the run."""
+
+
+def _headers(token: str | None, directory: str | None = None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if directory:
+        headers[DIRECTORY_HEADER] = directory
+    return headers
+
+
+def check_health(base_url: str, token: str | None = None) -> dict[str, Any]:
+    """Probe ``GET /health``; returns the payload or raises RemoteServerError."""
+    try:
+        response = httpx.get(f"{base_url.rstrip('/')}/health", headers=_headers(token), timeout=10.0)
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPError as e:
+        raise RemoteServerError(f"server at {base_url} is not reachable: {e}") from e
+    if payload.get("status") != "ok":
+        raise RemoteServerError(f"server at {base_url} reported status {payload.get('status')!r}")
+    return payload
+
+
+async def run_journey_remote(
+    base_url: str,
+    token: str | None,
+    directory: str,
+    request: JourneyAnalyseRequest,
+) -> dict[str, Any]:
+    """Run the canned journey analysis on a remote server.
+
+    Subscribes to ``/event`` before POSTing ``/journey/analyse`` (so no
+    progress is missed), folds the stream into status lines, and returns
+    the finished run's artifact part properties (``path``, ``summary``).
+    Paths in ``request`` are interpreted on the *server's* filesystem.
+    Cancellation aborts the remote session tree before propagating.
+    """
+    base_url = base_url.rstrip("/")
+    session_id: str | None = None
+    async with httpx.AsyncClient(base_url=base_url, headers=_headers(token), timeout=httpx.Timeout(30.0)) as client:
+        try:
+            async with client.stream(
+                "GET", "/event", headers=_headers(token, directory), timeout=httpx.Timeout(30.0, read=None)
+            ) as stream:
+                if stream.status_code != 200:
+                    raise RemoteServerError(f"event stream refused: HTTP {stream.status_code}")
+
+                post = asyncio.create_task(
+                    client.post(
+                        "/journey/analyse",
+                        json=request.model_dump(mode="json", by_alias=True),
+                        headers=_headers(token, directory),
+                    )
+                )
+                try:
+                    tracker = _RunTracker()
+                    pending: list[dict[str, Any]] = []
+                    async for event in _sse_events(stream):
+                        if session_id is None:
+                            pending.append(event)
+                            if post.done():
+                                session_id = _session_from_response(post.result())
+                                tracker.session_id = session_id
+                                for buffered in pending:
+                                    if tracker.handle(buffered):
+                                        return await _fetch_artifact(client, token, session_id)
+                                pending.clear()
+                            continue
+                        if tracker.handle(event):
+                            return await _fetch_artifact(client, token, session_id)
+                    raise RemoteServerError("event stream ended before the run finished")
+                finally:
+                    if not post.done():
+                        post.cancel()
+                    await asyncio.gather(post, return_exceptions=True)
+        except asyncio.CancelledError:
+            if session_id is not None:
+                await asyncio.shield(_abort(base_url, token, session_id))
+            raise
+
+
+def _session_from_response(response: httpx.Response) -> str:
+    if response.status_code == 503:
+        raise RemoteServerError(f"server has no LLM credentials configured: {_detail(response)}")
+    if response.status_code != 202:
+        raise RemoteServerError(f"analyse request failed: HTTP {response.status_code}: {_detail(response)}")
+    session_id = response.json().get("sessionId")
+    if not session_id:
+        raise RemoteServerError("analyse response carried no sessionId")
+    status(f"remote run started (session {session_id})")
+    return session_id
+
+
+def _detail(response: httpx.Response) -> str:
+    try:
+        return str(response.json().get("detail", response.text))
+    except Exception:  # noqa: BLE001
+        return response.text
+
+
+class _RunTracker:
+    """Folds bus events for one session tree into status lines.
+
+    ``handle`` returns True when the root session finished successfully and
+    raises :class:`RemoteServerError` when it errored.
+    """
+
+    def __init__(self) -> None:
+        self.session_id: str | None = None
+        self._children: dict[str, str] = {}  # child session id -> agent name
+        self._milestones = 0
+
+    def _mine(self, sid: str | None) -> bool:
+        return sid is not None and (sid == self.session_id or sid in self._children)
+
+    def handle(self, event: dict[str, Any]) -> bool:
+        kind = event.get("type")
+        properties = event.get("properties") or {}
+        if kind == "session.created":
+            session = properties.get("session") or {}
+            if session.get("parentId") == self.session_id:
+                self._children[session["id"]] = session.get("agent", "?")
+                status(f"subagent started: {session.get('agent', '?')} — {session.get('title') or session['id']}")
+        elif kind == "session.idle":
+            session = properties.get("session") or {}
+            agent = self._children.get(session.get("id", ""))
+            if agent is not None:
+                status(f"subagent finished: {agent}")
+            elif session.get("id") == self.session_id:
+                status(f"run finished — {self._milestones} milestone(s) emitted")
+                return True
+        elif kind == "session.error":
+            session = properties.get("session") or {}
+            if self._mine(session.get("id")):
+                raise RemoteServerError(f"remote run failed: {properties.get('error') or 'unknown error'}")
+        elif kind == "part.created":
+            part = properties.get("part") or {}
+            if not self._mine(part.get("sessionId")):
+                return False
+            if part.get("type") == "milestone":
+                self._milestones += 1
+                proposed = (part.get("milestone") or {}).get("proposedId", "?")
+                status(f"milestone: {proposed}")
+            elif part.get("type") == "tool" and part.get("sessionId") == self.session_id:
+                status(f"tool started: {part.get('tool', '?')}")
+        elif kind == "part.updated":
+            part = properties.get("part") or {}
+            if part.get("type") == "tool" and part.get("sessionId") == self.session_id:
+                state = (part.get("state") or {}).get("status", "?")
+                if state in ("completed", "error"):
+                    status(f"tool {state}: {part.get('tool', '?')}")
+        return False
+
+
+async def _sse_events(stream: httpx.Response):
+    """Decode ``data:``-framed SSE into event dicts (the phase-4 contract)."""
+    data: list[str] = []
+    size = 0
+    async for line in stream.aiter_lines():
+        if not line.strip():
+            if data:
+                payload, size = "\n".join(data), 0
+                data.clear()
+                try:
+                    event = json.loads(payload)
+                except json.JSONDecodeError:
+                    warning("skipping unparseable event frame")
+                    continue
+                if isinstance(event, dict):
+                    yield event
+            continue
+        if line.startswith("data:"):
+            chunk = line[5:].removeprefix(" ")
+            size += len(chunk)
+            if size > _MAX_EVENT_SIZE:
+                raise RemoteServerError("event frame exceeds size cap — broken stream")
+            data.append(chunk)
+
+
+async def _fetch_artifact(client: httpx.AsyncClient, token: str | None, session_id: str) -> dict[str, Any]:
+    response = await client.get(f"/session/{session_id}/message", headers=_headers(token))
+    response.raise_for_status()
+    for message in response.json():
+        for part in message.get("parts", []):
+            if part.get("type") == "artifact":
+                return part
+    raise RemoteServerError("run finished but produced no artifact part")
+
+
+async def _abort(base_url: str, token: str | None, session_id: str) -> None:
+    """Best-effort abort on a fresh connection (ours may be mid-stream)."""
+    try:
+        async with httpx.AsyncClient(base_url=base_url, headers=_headers(token), timeout=10.0) as client:
+            await client.post(f"/session/{session_id}/abort")
+        status(f"remote run aborted (session {session_id})")
+    except httpx.HTTPError as e:  # noqa: BLE001 — abort is best-effort
+        warning(f"could not abort remote session {session_id}: {e}")

--- a/src/skene/core/embedded.py
+++ b/src/skene/core/embedded.py
@@ -29,7 +29,9 @@ async def run_journey_embedded(
     """
     services = await create_services(db_path, llm_factory=lambda: llm)
     try:
-        handle = await start_journey_run(services.sessions, services.registry, str(directory), request, llm=llm)
+        handle = await start_journey_run(
+            services.sessions, services.registry, str(directory), request, llm=llm, permissions=services.permissions
+        )
         try:
             return await handle.result
         finally:

--- a/src/skene/core/journey.py
+++ b/src/skene/core/journey.py
@@ -36,6 +36,7 @@ from skene.analyzers.journey.specialize import specialize_stages
 from skene.analyzers.journey.stages import STAGES
 from skene.analyzers.schema_parsers.models import SchemaIndex
 from skene.core.agents import AgentDef, AgentRegistry
+from skene.core.permissions import PermissionService
 from skene.core.redact import redact_db_url
 from skene.core.sessions import RunFactory, SessionService
 from skene.core.store import now_ms
@@ -98,6 +99,7 @@ class JourneyRunContext:
         config: JourneyRunConfig,
         llm: LLMClient | None = None,
         result: "asyncio.Future[Journey] | None" = None,
+        permissions: PermissionService | None = None,
     ) -> None:
         self.sessions = sessions
         self.registry = registry
@@ -105,6 +107,9 @@ class JourneyRunContext:
         self.config = config
         self.llm = llm
         self.result = result
+        # For tool closures that guard side effects behind an ask (none of
+        # the built-in journey tools do yet — they are read-only).
+        self.permissions = permissions
         self.message_id: str | None = None
         self.journey: Journey | None = None
         self._schema_index: SchemaIndex | None = None
@@ -313,23 +318,37 @@ async def _finalize_journey(ctx: JourneyRunContext) -> str:
 # ---------------------------------------------------------------------------
 
 
-def make_run_factory(sessions: SessionService, registry: AgentRegistry) -> RunFactory:
+def make_run_factory(
+    sessions: SessionService, registry: AgentRegistry, permissions: PermissionService | None = None
+) -> RunFactory:
     """Prompt dispatch: primary agents get the main-agent flow with
     workspace defaults; everything else keeps the chat fallback."""
 
     def factory(session: Session, text: str):
-        return _prompt_run(sessions, registry, session, text)
+        return _prompt_run(sessions, registry, permissions, session, text)
 
     return factory
 
 
-async def _prompt_run(sessions: SessionService, registry: AgentRegistry, session: Session, text: str) -> None:
+async def _prompt_run(
+    sessions: SessionService,
+    registry: AgentRegistry,
+    permissions: PermissionService | None,
+    session: Session,
+    text: str,
+) -> None:
     agent = registry.get(session.agent)
     if agent is None or agent.mode != "primary":
         await sessions.chat_run(session, text)
         return
     directory = await sessions.store.session_directory(session.id)
-    ctx = JourneyRunContext(sessions=sessions, registry=registry, session=session, config=_default_config(directory))
+    ctx = JourneyRunContext(
+        sessions=sessions,
+        registry=registry,
+        session=session,
+        config=_default_config(directory),
+        permissions=permissions,
+    )
     await _agent_run(ctx, agent, text)
 
 
@@ -349,6 +368,7 @@ async def _agent_run(ctx: JourneyRunContext, agent: AgentDef, initial_input: str
             initial_input=initial_input,
             max_turns=agent.max_turns,
             llm=ctx.llm,
+            model=agent.model,
             on_start=on_start,
         )
     except asyncio.CancelledError:
@@ -383,6 +403,7 @@ async def start_journey_run(
     directory: str,
     request: JourneyAnalyseRequest,
     llm: LLMClient | None = None,
+    permissions: PermissionService | None = None,
 ) -> JourneyRunHandle:
     """Create a ``skene`` session and send it the canned analyse prompt.
 
@@ -395,7 +416,8 @@ async def start_journey_run(
     agent = registry.get("skene")
     if agent is None or agent.mode != "primary":
         raise JourneyRequestError("registry has no primary 'skene' agent")
-    llm = llm or sessions.llm_factory()  # resolve before creating anything: no orphan session on missing credentials
+    # Resolve before creating anything: no orphan session on missing credentials.
+    llm = llm or sessions.resolve_llm(agent.model)
 
     session = await sessions.create_session(
         directory, agent=agent.name, title=f"analyse-journey: {config.product_name}"
@@ -407,7 +429,13 @@ async def start_journey_run(
 
     result: asyncio.Future[Journey] = asyncio.get_running_loop().create_future()
     ctx = JourneyRunContext(
-        sessions=sessions, registry=registry, session=session, config=config, llm=llm, result=result
+        sessions=sessions,
+        registry=registry,
+        session=session,
+        config=config,
+        llm=llm,
+        result=result,
+        permissions=permissions,
     )
     sessions.start_run(session, _agent_run(ctx, agent, prompt))
     return JourneyRunHandle(session=session, result=result)

--- a/src/skene/core/permissions.py
+++ b/src/skene/core/permissions.py
@@ -1,0 +1,114 @@
+"""The permission ask/answer flow (phase 5).
+
+A tool handler that wants to do something guarded calls
+:meth:`PermissionService.ask` and suspends until a client answers via
+``POST /session/{id}/permissions/{permID}`` (``permission.asked`` /
+``permission.answered`` land on the bus around it). Tools reach the
+service the same way the task tool reaches ``SessionService`` — by
+closure over the run context — so the agent loop stays permission-free.
+
+Design choices, deliberate and minimal:
+
+- No rulesets yet (the design doc's allow/deny rules are future work):
+  every ask goes to the client.
+- No timeout: an ask stays pending until answered or the run is aborted.
+  Abort cancels the awaiting tool handler; the cancellation path records
+  the request as denied so nothing dangles in the DB or in clients.
+- One-shot answers: answering a non-pending request is a conflict.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from skene.core.bus import Bus
+from skene.core.store import Store, UnknownPermissionError, now_ms
+from skene.schema import (
+    PermissionAnswered,
+    PermissionAsked,
+    PermissionReply,
+    PermissionRequest,
+    new_id,
+)
+
+
+class PermissionAlreadyAnsweredError(RuntimeError):
+    """Raised when answering a request that is no longer pending."""
+
+
+class PermissionService:
+    def __init__(self, store: Store, bus: Bus) -> None:
+        self.store = store
+        self.bus = bus
+        self._pending: dict[str, asyncio.Future[bool]] = {}
+
+    async def ask(
+        self,
+        session_id: str,
+        *,
+        tool: str,
+        title: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Ask the client for permission; True means allowed.
+
+        Blocks until a client answers. When the surrounding run is
+        aborted, the request is recorded as denied and the cancellation
+        propagates to the caller.
+        """
+        directory = await self.store.session_directory(session_id)
+        request = PermissionRequest(
+            id=new_id("prm"),
+            session_id=session_id,
+            tool=tool,
+            title=title,
+            metadata=metadata or {},
+            created=now_ms(),
+        )
+        await self.store.save_permission(request)
+        self.bus.publish(PermissionAsked(properties={"request": request}), directory=directory)
+
+        future: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        self._pending[request.id] = future
+        try:
+            return await future
+        except asyncio.CancelledError:
+            # Run aborted while waiting — resolve the request as denied so
+            # clients drop the prompt. Shielded: a second cancel must not
+            # strand the request half-answered.
+            await asyncio.shield(self._record_answer(request, "deny", directory))
+            raise
+        finally:
+            self._pending.pop(request.id, None)
+
+    async def answer(self, perm_id: str, reply: PermissionReply) -> PermissionRequest:
+        """Resolve a pending ask; the awaiting tool handler resumes.
+
+        Raises :class:`UnknownPermissionError` for unknown ids and
+        :class:`PermissionAlreadyAnsweredError` for non-pending requests.
+        Answering an ask whose waiter is gone (e.g. after a server
+        restart) still records the answer.
+        """
+        request = await self.store.get_permission(perm_id)
+        if request.status != "pending":
+            raise PermissionAlreadyAnsweredError(perm_id)
+        directory = await self.store.session_directory(request.session_id)
+        request = await self._record_answer(request, reply, directory)
+        future = self._pending.get(perm_id)
+        if future is not None and not future.done():
+            future.set_result(reply == "allow")
+        return request
+
+    async def _record_answer(
+        self, request: PermissionRequest, reply: PermissionReply, directory: str
+    ) -> PermissionRequest:
+        request = request.model_copy(
+            update={"status": "allowed" if reply == "allow" else "denied", "answered": now_ms()}
+        )
+        await self.store.save_permission(request)
+        self.bus.publish(PermissionAnswered(properties={"request": request}), directory=directory)
+        return request
+
+
+__all__ = ["PermissionAlreadyAnsweredError", "PermissionService", "UnknownPermissionError"]

--- a/src/skene/core/services.py
+++ b/src/skene/core/services.py
@@ -14,8 +14,10 @@ from pathlib import Path
 from skene.core.agents import AgentRegistry
 from skene.core.bus import Bus
 from skene.core.journey import make_run_factory
+from skene.core.permissions import PermissionService
 from skene.core.sessions import LLMFactory, SessionService
 from skene.core.store import DEFAULT_DB_PATH, Store
+from skene.schema import ServerConfigInfo
 
 
 def resolve_db_path(db_path: Path | str | None = None) -> Path:
@@ -43,6 +45,10 @@ class CoreServices:
     bus: Bus
     sessions: SessionService
     registry: AgentRegistry
+    permissions: PermissionService
+    # Startup-resolved LLM config snapshot for GET /config and GET /provider;
+    # None for bare service setups (tests, embedded CLI).
+    config_info: ServerConfigInfo | None = None
 
     async def close(self) -> None:
         await self.store.close()
@@ -52,10 +58,19 @@ async def create_services(
     db_path: Path | str | None = None,
     llm_factory: LLMFactory | None = None,
     registry: AgentRegistry | None = None,
+    config_info: ServerConfigInfo | None = None,
 ) -> CoreServices:
     store = await Store.open(resolve_db_path(db_path))
     bus = Bus()
     registry = registry or AgentRegistry()
+    permissions = PermissionService(store, bus)
     sessions = SessionService(store, bus, llm_factory or _no_llm_configured())
-    sessions.run_factory = make_run_factory(sessions, registry)
-    return CoreServices(store=store, bus=bus, sessions=sessions, registry=registry)
+    sessions.run_factory = make_run_factory(sessions, registry, permissions)
+    return CoreServices(
+        store=store,
+        bus=bus,
+        sessions=sessions,
+        registry=registry,
+        permissions=permissions,
+        config_info=config_info,
+    )

--- a/src/skene/core/sessions.py
+++ b/src/skene/core/sessions.py
@@ -27,6 +27,7 @@ tool-less chat run.
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from typing import Any
 
@@ -75,7 +76,9 @@ _CHAT_INSTRUCTIONS = (
     "in this session."
 )
 
-LLMFactory = Callable[[], LLMClient]
+# Called with no arguments for the default client; a factory that also
+# accepts a ``model`` keyword opts in to per-agent overrides (AgentDef.model).
+LLMFactory = Callable[..., LLMClient]
 
 # Builds the background run for a prompt; see skene.core.journey.make_run_factory.
 RunFactory = Callable[["Session", str], Coroutine[Any, Any, None]]
@@ -207,6 +210,26 @@ class SessionService:
         run = self._runs.get(session_id)
         return run.abort if run is not None else None
 
+    # -- LLM resolution ---------------------------------------------------------
+
+    def resolve_llm(self, model: str | None = None) -> LLMClient:
+        """A client from the service factory, honouring a per-agent model.
+
+        Overrides need a factory that accepts ``model`` (``skene serve``
+        wires one); with a zero-arg factory (tests, the embedded CLI's
+        pinned client) the override is ignored with a debug note.
+        """
+        if model is None:
+            return self.llm_factory()
+        try:
+            accepts_model = "model" in inspect.signature(self.llm_factory).parameters
+        except (TypeError, ValueError):
+            accepts_model = False
+        if accepts_model:
+            return self.llm_factory(model=model)
+        debug(f"llm factory does not accept model overrides; ignoring model={model!r}")
+        return self.llm_factory()
+
     # -- run coordinator -------------------------------------------------------
 
     async def set_status(self, session: Session, status: str, *, error: str | None = None) -> Session:
@@ -293,6 +316,7 @@ class SessionService:
         initial_input: str,
         max_turns: int = 20,
         llm: LLMClient | None = None,
+        model: str | None = None,
         wrap_stream: StreamWrapper | None = None,
         on_start: Callable[[LLMClient, AssistantMessage], None] | None = None,
     ) -> AgentRunResult:
@@ -306,13 +330,14 @@ class SessionService:
         re-raised for the caller's own cleanup (futures, child aborts).
 
         ``llm`` defaults to the service factory (resolved inside the run so
-        credential failures surface as session errors); ``on_start`` fires
-        after the assistant message exists, with the resolved client.
+        credential failures surface as session errors), with ``model`` as
+        the per-agent override passed to :meth:`resolve_llm`; ``on_start``
+        fires after the assistant message exists, with the resolved client.
         """
         message = AssistantMessage(id=new_id("msg"), session_id=session.id, created=now_ms(), agent=session.agent)
         try:
             session = await self.set_status(session, "running")
-            llm = llm if llm is not None else self.llm_factory()
+            llm = llm if llm is not None else self.resolve_llm(model)
             message = message.model_copy(update={"provider": llm.get_provider_name(), "model": llm.get_model_name()})
             await self.emit_message(message)
             if on_start is not None:

--- a/src/skene/core/store.py
+++ b/src/skene/core/store.py
@@ -20,7 +20,7 @@ import aiosqlite
 from pydantic import TypeAdapter
 
 from skene.core.bus import normalize_directory
-from skene.schema import Message, Part, Project, Session, new_id
+from skene.schema import Message, Part, PermissionRequest, Project, Session, new_id
 
 DEFAULT_DB_PATH = Path("~/.local/share/skene/skene.db").expanduser()
 
@@ -63,6 +63,14 @@ CREATE TABLE IF NOT EXISTS part (
     data       TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_part_message ON part(message_id, created);
+CREATE TABLE IF NOT EXISTS permission_request (
+    id         TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES session(id),
+    status     TEXT NOT NULL,
+    created    INTEGER NOT NULL,
+    data       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_permission_session ON permission_request(session_id, created);
 """
 
 
@@ -72,6 +80,10 @@ def now_ms() -> int:
 
 class UnknownSessionError(KeyError):
     """Raised when a session id does not exist."""
+
+
+class UnknownPermissionError(KeyError):
+    """Raised when a permission request id does not exist."""
 
 
 class Store:
@@ -249,11 +261,36 @@ class Store:
             result.append((message, parts_by_message.get(message.id, [])))
         return result
 
+    # -- permission requests ---------------------------------------------------
+
+    async def save_permission(self, request: PermissionRequest) -> None:
+        """Insert or replace a permission request (answers rewrite the JSON)."""
+        await self._db.execute(
+            "INSERT INTO permission_request (id, session_id, status, created, data) VALUES (?, ?, ?, ?, ?)"
+            " ON CONFLICT(id) DO UPDATE SET status = excluded.status, data = excluded.data",
+            (request.id, request.session_id, request.status, request.created, request.model_dump_json()),
+        )
+        await self._db.commit()
+
+    async def get_permission(self, perm_id: str) -> PermissionRequest:
+        async with self._db.execute("SELECT data FROM permission_request WHERE id = ?", (perm_id,)) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise UnknownPermissionError(perm_id)
+        return PermissionRequest.model_validate_json(row["data"])
+
+    async def list_permissions(self, session_id: str) -> list[PermissionRequest]:
+        async with self._db.execute(
+            "SELECT data FROM permission_request WHERE session_id = ? ORDER BY created, id", (session_id,)
+        ) as cur:
+            rows = await cur.fetchall()
+        return [PermissionRequest.model_validate_json(row["data"]) for row in rows]
+
     # -- diagnostics ----------------------------------------------------------
 
     async def counts(self) -> dict[str, Any]:
         out: dict[str, Any] = {}
-        for table in ("project", "session", "message", "part"):
+        for table in ("project", "session", "message", "part", "permission_request"):
             async with self._db.execute(f"SELECT COUNT(*) AS n FROM {table}") as cur:  # noqa: S608
                 row = await cur.fetchone()
             out[table] = row["n"]

--- a/src/skene/core/tasks.py
+++ b/src/skene/core/tasks.py
@@ -125,7 +125,11 @@ async def _run_task(ctx: "JourneyRunContext", args: dict) -> str:
 
     status(f"task: {name} subagent started (session {child.id}, max_turns={_max_turns(ctx, agent)})")
     outcome: asyncio.Future[SubagentOutcome] = asyncio.get_running_loop().create_future()
-    sessions.start_run(child, _subagent_run(sessions, child, agent, ctx.llm, tools, collector, prompt, ctx, outcome))
+    # A subagent with its own model resolves a fresh client inside the run
+    # (execute_run surfaces credential failures as session state); otherwise
+    # it shares the parent's client.
+    llm = None if agent.model is not None else ctx.llm
+    sessions.start_run(child, _subagent_run(sessions, child, agent, llm, tools, collector, prompt, ctx, outcome))
     try:
         result = await outcome
     except asyncio.CancelledError:
@@ -190,6 +194,7 @@ async def _subagent_run(
             initial_input=prompt,
             max_turns=_max_turns(ctx, agent),
             llm=llm,
+            model=agent.model,
             wrap_stream=wrap,
         )
         await sessions.set_status(child, "idle")

--- a/src/skene/schema/__init__.py
+++ b/src/skene/schema/__init__.py
@@ -10,12 +10,15 @@ models accept both on input.
 """
 
 from skene.schema.agent import AgentInfo, AgentMode
+from skene.schema.config import ProviderInfo, ServerConfigInfo
 from skene.schema.event import (
     Event,
     MessageCreated,
     MessageUpdated,
     PartCreated,
     PartUpdated,
+    PermissionAnswered,
+    PermissionAsked,
     ServerConnected,
     ServerHeartbeat,
     SessionCreated,
@@ -48,6 +51,12 @@ from skene.schema.milestone import (
     Evidence,
     EvidenceSource,
 )
+from skene.schema.permission import (
+    PermissionAnswer,
+    PermissionReply,
+    PermissionRequest,
+    PermissionStatus,
+)
 from skene.schema.request import (
     JourneyAnalyseAccepted,
     JourneyAnalyseRequest,
@@ -77,9 +86,17 @@ __all__ = [
     "Part",
     "PartCreated",
     "PartUpdated",
+    "PermissionAnswer",
+    "PermissionAnswered",
+    "PermissionAsked",
+    "PermissionReply",
+    "PermissionRequest",
+    "PermissionStatus",
     "Project",
     "PromptRequest",
+    "ProviderInfo",
     "ReasoningPart",
+    "ServerConfigInfo",
     "ServerConnected",
     "ServerHeartbeat",
     "Session",

--- a/src/skene/schema/config.py
+++ b/src/skene/schema/config.py
@@ -1,0 +1,33 @@
+"""Config / provider surface wire models (phase 5).
+
+``GET /config`` is deliberately read-only: the server resolves its LLM
+config once at startup (flags/env/.skene.config), so changing it means
+restarting the server — a PATCH that rebuilt the factory mid-flight was
+considered and rejected for now. Secrets never appear here: the API key
+is reported only as a boolean.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from skene.schema.base import WireModel
+
+
+class ProviderInfo(WireModel):
+    """One supported LLM provider, as exposed by ``GET /provider``."""
+
+    name: str
+    models: list[str] = Field(default_factory=list)
+    # True for the provider the server was started with.
+    active: bool = False
+
+
+class ServerConfigInfo(WireModel):
+    """Resolved server configuration, secrets redacted (``GET /config``)."""
+
+    version: str
+    provider: str | None = None
+    model: str | None = None
+    base_url: str | None = None
+    api_key_configured: bool = False

--- a/src/skene/schema/event.py
+++ b/src/skene/schema/event.py
@@ -13,6 +13,7 @@ from pydantic import Field
 from skene.schema.base import WireModel
 from skene.schema.ids import new_id
 from skene.schema.message import Message, Part
+from skene.schema.permission import PermissionRequest
 from skene.schema.session import Session
 
 
@@ -107,6 +108,23 @@ class PartUpdated(_BaseEvent):
     properties: _PartProps
 
 
+# --- permissions --------------------------------------------------------------
+
+
+class _PermissionProps(WireModel):
+    request: PermissionRequest
+
+
+class PermissionAsked(_BaseEvent):
+    type: Literal["permission.asked"] = "permission.asked"
+    properties: _PermissionProps
+
+
+class PermissionAnswered(_BaseEvent):
+    type: Literal["permission.answered"] = "permission.answered"
+    properties: _PermissionProps
+
+
 Event = Annotated[
     Union[
         ServerConnected,
@@ -119,6 +137,8 @@ Event = Annotated[
         MessageUpdated,
         PartCreated,
         PartUpdated,
+        PermissionAsked,
+        PermissionAnswered,
     ],
     Field(discriminator="type"),
 ]

--- a/src/skene/schema/permission.py
+++ b/src/skene/schema/permission.py
@@ -1,0 +1,39 @@
+"""Permission ask/answer wire models (phase 5).
+
+A tool that wants to do something guarded (e.g. write to a live database)
+asks for permission mid-run: the run pauses on the ask, clients see a
+``permission.asked`` event, and one of them answers via
+``POST /session/{id}/permissions/{permID}``. There are no rulesets yet —
+every ask goes to the client and is answered once.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from skene.schema.base import WireModel
+
+PermissionStatus = Literal["pending", "allowed", "denied"]
+
+PermissionReply = Literal["allow", "deny"]
+
+
+class PermissionRequest(WireModel):
+    """One pending or answered ask, as persisted and streamed."""
+
+    id: str
+    session_id: str
+    tool: str
+    title: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    status: PermissionStatus = "pending"
+    created: int
+    answered: int | None = None
+
+
+class PermissionAnswer(WireModel):
+    """Body of ``POST /session/{id}/permissions/{permID}``."""
+
+    reply: PermissionReply

--- a/src/skene/server/app.py
+++ b/src/skene/server/app.py
@@ -21,9 +21,9 @@ from pydantic import TypeAdapter
 from skene import __version__
 from skene.core.services import CoreServices, create_services
 from skene.core.sessions import LLMFactory
-from skene.schema import Event
+from skene.schema import Event, ServerConfigInfo
 from skene.server.deps import require_auth
-from skene.server.routes import agent, event, journey, session
+from skene.server.routes import agent, config, event, journey, session
 
 
 def create_app(
@@ -32,11 +32,14 @@ def create_app(
     db_path: Path | str | None = None,
     llm_factory: LLMFactory | None = None,
     auth_token: str | None = None,
+    config_info: ServerConfigInfo | None = None,
 ) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         owned = services is None
-        app.state.services = services if services is not None else await create_services(db_path, llm_factory)
+        app.state.services = (
+            services if services is not None else await create_services(db_path, llm_factory, config_info=config_info)
+        )
         try:
             yield
         finally:
@@ -59,6 +62,7 @@ def create_app(
     app.include_router(event.router, dependencies=protected)
     app.include_router(journey.router, dependencies=protected)
     app.include_router(agent.router, dependencies=protected)
+    app.include_router(config.router, dependencies=protected)
 
     @app.get("/health", tags=["meta"])
     async def health() -> dict[str, str]:

--- a/src/skene/server/routes/config.py
+++ b/src/skene/server/routes/config.py
@@ -1,0 +1,49 @@
+"""The config / provider surface, read-only (phase 5).
+
+The server resolves its LLM configuration once at startup, so ``GET
+/config`` reports that snapshot and there is no PATCH: changing provider
+or credentials means restarting ``skene serve`` (a deliberate choice —
+rebuilding the LLM factory mid-flight buys nothing while runs are in
+progress). Secrets are redacted to a boolean.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from skene import __version__
+from skene.config import DEFAULT_MODEL_BY_PROVIDER
+from skene.schema import ProviderInfo, ServerConfigInfo
+from skene.server.deps import Services
+
+router = APIRouter(tags=["config"])
+
+# The canonical provider names understood by skene.llm.factory (aliases
+# like "claude" or "lm-studio" are accepted on input but not listed).
+_SUPPORTED_PROVIDERS = ("skene", "anthropic", "openai", "gemini", "lmstudio", "ollama", "generic")
+
+
+@router.get("/config", response_model=ServerConfigInfo)
+async def get_config(services: Services) -> ServerConfigInfo:
+    """The server's resolved LLM configuration, secrets redacted."""
+    info = services.config_info
+    if info is None:
+        return ServerConfigInfo(version=__version__)
+    return info.model_copy(update={"version": __version__})
+
+
+@router.get("/provider", response_model=list[ProviderInfo])
+async def list_providers(services: Services) -> list[ProviderInfo]:
+    """Supported LLM providers; ``active`` marks the one the server runs with."""
+    active = services.config_info.provider.lower() if services.config_info and services.config_info.provider else None
+    providers = []
+    for name in _SUPPORTED_PROVIDERS:
+        default_model = DEFAULT_MODEL_BY_PROVIDER.get(name)
+        providers.append(
+            ProviderInfo(
+                name=name,
+                models=[default_model] if default_model else [],
+                active=name == active,
+            )
+        )
+    return providers

--- a/src/skene/server/routes/journey.py
+++ b/src/skene/server/routes/journey.py
@@ -24,7 +24,9 @@ async def analyse(body: JourneyAnalyseRequest, services: Services, directory: Di
     as an ``artifact`` part (and as ``journey.yaml`` in the workspace).
     """
     try:
-        handle = await start_journey_run(services.sessions, services.registry, directory, body)
+        handle = await start_journey_run(
+            services.sessions, services.registry, directory, body, permissions=services.permissions
+        )
     except JourneyRequestError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except RuntimeError as e:

--- a/src/skene/server/routes/session.py
+++ b/src/skene/server/routes/session.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
+from skene.core.permissions import PermissionAlreadyAnsweredError
 from skene.core.sessions import SessionBusyError
-from skene.core.store import UnknownSessionError
+from skene.core.store import UnknownPermissionError, UnknownSessionError
 from skene.schema import (
     Message,
     MessageWithParts,
+    PermissionAnswer,
+    PermissionRequest,
     PromptRequest,
     Session,
     SessionCreateRequest,
@@ -79,3 +82,30 @@ async def abort(session_id: str, services: Services) -> dict[str, bool]:
     except UnknownSessionError as e:
         raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
     return {"aborted": aborted}
+
+
+@router.get("/session/{session_id}/permissions", response_model=list[PermissionRequest])
+async def list_permissions(session_id: str, services: Services) -> list[PermissionRequest]:
+    """Every permission request the session has raised, pending first-created first."""
+    try:
+        await services.store.get_session(session_id)
+    except UnknownSessionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown session: {session_id}") from e
+    return await services.store.list_permissions(session_id)
+
+
+@router.post("/session/{session_id}/permissions/{perm_id}", response_model=PermissionRequest)
+async def answer_permission(
+    session_id: str, perm_id: str, body: PermissionAnswer, services: Services
+) -> PermissionRequest:
+    """Answer a pending ask; the paused tool handler resumes with the verdict."""
+    try:
+        request = await services.store.get_permission(perm_id)
+    except UnknownPermissionError as e:
+        raise HTTPException(status_code=404, detail=f"unknown permission request: {perm_id}") from e
+    if request.session_id != session_id:
+        raise HTTPException(status_code=404, detail=f"permission request {perm_id} is not part of session {session_id}")
+    try:
+        return await services.permissions.answer(perm_id, body.reply)
+    except PermissionAlreadyAnsweredError as e:
+        raise HTTPException(status_code=409, detail=f"permission request already answered: {request.status}") from e

--- a/tests/test_cli/test_attach_remote.py
+++ b/tests/test_cli/test_attach_remote.py
@@ -1,0 +1,83 @@
+"""Tests for `skene attach` config persistence and the remote run client."""
+
+from __future__ import annotations
+
+import pytest
+
+from skene.cli.commands.attach import _upsert_config_keys
+from skene.cli.remote import RemoteServerError, _RunTracker
+
+
+class TestUpsertConfigKeys:
+    def test_adds_keys_to_missing_file(self, tmp_path):
+        path = tmp_path / ".skene.config"
+        _upsert_config_keys(path, {"server_url": "http://127.0.0.1:4906", "server_token": None})
+        text = path.read_text()
+        assert 'server_url = "http://127.0.0.1:4906"' in text
+        assert "server_token" not in text
+
+    def test_replaces_existing_and_preserves_others(self, tmp_path):
+        path = tmp_path / ".skene.config"
+        path.write_text('provider = "gemini"\nserver_url = "http://old:1"\n')
+        _upsert_config_keys(path, {"server_url": "http://new:2"})
+        text = path.read_text()
+        assert 'provider = "gemini"' in text
+        assert 'server_url = "http://new:2"' in text
+        assert "http://old:1" not in text
+
+    def test_none_removes_key(self, tmp_path):
+        path = tmp_path / ".skene.config"
+        path.write_text('server_url = "http://old:1"\nserver_token = "t"\nmodel = "m"\n')
+        _upsert_config_keys(path, {"server_url": None, "server_token": None})
+        text = path.read_text()
+        assert "server_url" not in text and "server_token" not in text
+        assert 'model = "m"' in text
+
+    def test_result_is_valid_toml(self, tmp_path):
+        from skene.config import load_toml
+
+        path = tmp_path / ".skene.config"
+        path.write_text('provider = "gemini"\n')
+        _upsert_config_keys(path, {"server_url": "http://h:1", "server_token": "tok"})
+        data = load_toml(path)
+        assert data == {"provider": "gemini", "server_url": "http://h:1", "server_token": "tok"}
+
+
+def _session_event(kind, sid, parent=None, agent="skene", error=None, title=None):
+    properties = {"session": {"id": sid, "parentId": parent, "agent": agent, "title": title}}
+    if error is not None:
+        properties["error"] = error
+    return {"type": kind, "properties": properties}
+
+
+class TestRunTracker:
+    def _tracker(self):
+        tracker = _RunTracker()
+        tracker.session_id = "ses_root"
+        return tracker
+
+    def test_root_idle_finishes(self):
+        tracker = self._tracker()
+        assert tracker.handle(_session_event("session.idle", "ses_root")) is True
+
+    def test_child_lifecycle_and_milestones(self):
+        tracker = self._tracker()
+        assert tracker.handle(_session_event("session.created", "ses_child", parent="ses_root", agent="code")) is False
+        assert tracker.handle(_session_event("session.idle", "ses_child")) is False
+        part = {"type": "milestone", "sessionId": "ses_child", "milestone": {"proposedId": "user_signs_up"}}
+        assert tracker.handle({"type": "part.created", "properties": {"part": part}}) is False
+        assert tracker._milestones == 1
+
+    def test_foreign_sessions_are_ignored(self):
+        tracker = self._tracker()
+        assert tracker.handle(_session_event("session.idle", "ses_other")) is False
+        with pytest.raises(RemoteServerError):
+            tracker.handle(_session_event("session.error", "ses_root", error="boom"))
+        # An error in an unrelated tree does not raise.
+        assert tracker.handle(_session_event("session.error", "ses_stranger", error="boom")) is False
+
+    def test_child_error_raises(self):
+        tracker = self._tracker()
+        tracker.handle(_session_event("session.created", "ses_child", parent="ses_root", agent="code"))
+        with pytest.raises(RemoteServerError, match="boom"):
+            tracker.handle(_session_event("session.error", "ses_child", error="boom"))

--- a/tests/test_core/test_permissions.py
+++ b/tests/test_core/test_permissions.py
@@ -1,0 +1,95 @@
+"""Tests for the permission ask/answer flow."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from skene.core.permissions import PermissionAlreadyAnsweredError, UnknownPermissionError
+from skene.schema import PermissionAnswered, PermissionAsked
+
+
+async def _pending_request(services, workspace):
+    """Start an ask in the background and return (task, asked event)."""
+    session = await services.sessions.create_session(str(workspace))
+    sub = services.bus.subscribe(workspace)
+    task = asyncio.create_task(
+        services.permissions.ask(
+            session.id, tool="write_db", title="Write to table users?", metadata={"table": "users"}
+        )
+    )
+    while True:
+        event = await sub.get(timeout=1)
+        assert event is not None, "no permission.asked event"
+        if isinstance(event, PermissionAsked):
+            return session, sub, task, event.properties.request
+
+
+async def test_ask_allow_resumes_with_true(services, workspace):
+    session, sub, task, request = await _pending_request(services, workspace)
+    assert request.status == "pending"
+    assert request.tool == "write_db"
+    assert request.id.startswith("prm_")
+
+    answered = await services.permissions.answer(request.id, "allow")
+    assert answered.status == "allowed"
+    assert answered.answered is not None
+    assert await task is True
+
+    # Answer persisted + published.
+    stored = await services.store.get_permission(request.id)
+    assert stored.status == "allowed"
+    while (event := await sub.get(timeout=0.05)) is not None:
+        if isinstance(event, PermissionAnswered):
+            assert event.properties.request.status == "allowed"
+            break
+    else:
+        pytest.fail("no permission.answered event")
+
+    assert await services.store.list_permissions(session.id) == [stored]
+
+
+async def test_ask_deny_resumes_with_false(services, workspace):
+    _session, _sub, task, request = await _pending_request(services, workspace)
+    await services.permissions.answer(request.id, "deny")
+    assert await task is False
+    assert (await services.store.get_permission(request.id)).status == "denied"
+
+
+async def test_answer_unknown_and_already_answered(services, workspace):
+    _session, _sub, task, request = await _pending_request(services, workspace)
+    with pytest.raises(UnknownPermissionError):
+        await services.permissions.answer("prm_nope", "allow")
+    await services.permissions.answer(request.id, "allow")
+    await task
+    with pytest.raises(PermissionAlreadyAnsweredError):
+        await services.permissions.answer(request.id, "deny")
+    # The second answer did not overwrite the first.
+    assert (await services.store.get_permission(request.id)).status == "allowed"
+
+
+async def test_cancelled_ask_is_recorded_denied(services, workspace):
+    _session, sub, task, request = await _pending_request(services, workspace)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert (await services.store.get_permission(request.id)).status == "denied"
+    answered = None
+    while (event := await sub.get(timeout=0.05)) is not None:
+        if isinstance(event, PermissionAnswered):
+            answered = event
+    assert answered is not None, "cancellation must publish permission.answered"
+
+
+async def test_answer_without_waiter_still_records(services, workspace):
+    """A pending request whose waiter is gone (server restart) is still answerable."""
+    _session, _sub, task, request = await _pending_request(services, workspace)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # The cancel path answered it; simulate a fresh pending row instead.
+    fresh = request.model_copy(update={"id": "prm_restarted", "status": "pending"})
+    await services.store.save_permission(fresh)
+    answered = await services.permissions.answer("prm_restarted", "allow")
+    assert answered.status == "allowed"

--- a/tests/test_core/test_sessions.py
+++ b/tests/test_core/test_sessions.py
@@ -133,6 +133,25 @@ async def test_stream_events_are_scoped_to_directory(services, workspace, tmp_pa
     assert await outsider.get(timeout=0.05) is None
 
 
+async def test_resolve_llm_honours_model_override(services):
+    calls = []
+
+    def factory(model: str | None = None):
+        calls.append(model)
+        return ScriptedClient([turn(text="ok")])
+
+    services.sessions.llm_factory = factory
+    services.sessions.resolve_llm()
+    services.sessions.resolve_llm("cheap-model")
+    assert calls == [None, "cheap-model"]
+
+
+async def test_resolve_llm_ignores_override_for_pinned_factory(services):
+    client = ScriptedClient([turn(text="ok")])
+    services.sessions.llm_factory = lambda: client
+    assert services.sessions.resolve_llm("cheap-model") is client
+
+
 def _event_names(events: list) -> list[str]:
     return [type(e).__name__ for e in events]
 

--- a/tests/test_core/test_store.py
+++ b/tests/test_core/test_store.py
@@ -88,4 +88,4 @@ async def test_counts(services, workspace):
     project = await services.store.ensure_project(workspace)
     await services.store.create_session(project_id=project.id, agent="skene")
     counts = await services.store.counts()
-    assert counts == {"project": 1, "session": 1, "message": 0, "part": 0}
+    assert counts == {"project": 1, "session": 1, "message": 0, "part": 0, "permission_request": 0}

--- a/tests/test_server/test_api.py
+++ b/tests/test_server/test_api.py
@@ -184,6 +184,68 @@ async def test_bearer_auth(services, workspace):
         assert (await client.get("/health")).status_code == 200
 
 
+async def test_permission_ask_answer_flow(client, services):
+    import asyncio
+
+    session_id = (await client.post("/session", json={})).json()["id"]
+    ask = asyncio.create_task(services.permissions.ask(session_id, tool="write_db", title="Write to users?"))
+    while not (pending := (await client.get(f"/session/{session_id}/permissions")).json()):
+        await asyncio.sleep(0.01)
+
+    request = pending[0]
+    assert request["status"] == "pending"
+    assert request["sessionId"] == session_id
+    assert request["tool"] == "write_db"
+
+    answered = await client.post(f"/session/{session_id}/permissions/{request['id']}", json={"reply": "allow"})
+    assert answered.status_code == 200
+    assert answered.json()["status"] == "allowed"
+    assert await ask is True
+
+    # One-shot: a second answer conflicts.
+    again = await client.post(f"/session/{session_id}/permissions/{request['id']}", json={"reply": "deny"})
+    assert again.status_code == 409
+
+    # Unknown ids and wrong sessions are 404s.
+    assert (
+        await client.post(f"/session/{session_id}/permissions/prm_nope", json={"reply": "allow"})
+    ).status_code == 404
+    other_id = (await client.post("/session", json={})).json()["id"]
+    wrong = await client.post(f"/session/{other_id}/permissions/{request['id']}", json={"reply": "allow"})
+    assert wrong.status_code == 404
+    assert (await client.get("/session/ses_nope/permissions")).status_code == 404
+
+
+async def test_config_route_without_snapshot(client):
+    from skene import __version__
+
+    config = (await client.get("/config")).json()
+    assert config["version"] == __version__
+    assert config["provider"] is None
+    assert config["apiKeyConfigured"] is False
+
+
+async def test_config_route_reports_snapshot_without_secrets(services, workspace):
+    from skene.schema import ServerConfigInfo
+
+    services.config_info = ServerConfigInfo(
+        version="", provider="anthropic", model="claude-sonnet-4-5", api_key_configured=True
+    )
+    app = create_app(services)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://skene.test") as client:
+        config = (await client.get("/config")).json()
+        assert config["provider"] == "anthropic"
+        assert config["apiKeyConfigured"] is True
+        assert "apiKey" not in config  # only the boolean crosses the wire
+
+        providers = (await client.get("/provider")).json()
+        by_name = {p["name"]: p for p in providers}
+        assert by_name["anthropic"]["active"] is True
+        assert by_name["openai"]["active"] is False
+        assert "gemini" in by_name
+
+
 async def test_journey_analyse_503_when_no_llm_configured(client, services, workspace):
     def broken_factory():
         raise RuntimeError("no LLM configured")

--- a/tests/test_server/test_remote.py
+++ b/tests/test_server/test_remote.py
@@ -1,0 +1,71 @@
+"""End-to-end test for the remote journey client (`skene attach` path).
+
+Runs a real uvicorn server on a loopback port — the SSE stream can't be
+exercised through httpx's buffering ASGITransport (see the phase-2 note in
+docs/design/backend-server.md).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import uvicorn
+
+from skene.cli.remote import RemoteServerError, check_health, run_journey_remote
+from skene.core.services import create_services
+from skene.schema import JourneyAnalyseRequest
+from skene.server import create_app
+from tests.fakes import JourneyFakeLLM
+
+
+@pytest.fixture
+async def live_server(tmp_path: Path):
+    services = await create_services(tmp_path / "skene.db", llm_factory=lambda: JourneyFakeLLM())
+    server = uvicorn.Server(uvicorn.Config(create_app(services), host="127.0.0.1", port=0, log_level="error"))
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.01)
+    port = server.servers[0].sockets[0].getsockname()[1]
+    yield f"http://127.0.0.1:{port}"
+    server.should_exit = True
+    await task
+    await services.close()
+
+
+async def test_check_health_and_remote_run(live_server, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # The fake code subagent emits a milestone whose evidence path must exist.
+    (workspace / "index.tsx").write_text("export default () => null;\n")
+
+    # check_health is sync (CLI-side); run it off-loop so it can reach the
+    # uvicorn server sharing this test's event loop.
+    assert (await asyncio.to_thread(check_health, live_server))["status"] == "ok"
+
+    artifact = await run_journey_remote(
+        live_server,
+        None,
+        str(workspace),
+        JourneyAnalyseRequest(path=str(workspace), specialize=False),
+    )
+    assert artifact["type"] == "artifact"
+    assert artifact["path"].endswith("journey.yaml")
+    assert Path(artifact["path"]).is_file()
+    assert "Journey assembled" in (artifact["summary"] or "")
+
+
+async def test_check_health_unreachable():
+    with pytest.raises(RemoteServerError, match="not reachable"):
+        check_health("http://127.0.0.1:1")
+
+
+async def test_remote_run_surfaces_request_errors(live_server, tmp_path):
+    with pytest.raises(RemoteServerError, match="analyse request failed"):
+        await run_journey_remote(
+            live_server,
+            None,
+            str(tmp_path),
+            JourneyAnalyseRequest(path=str(tmp_path / "missing")),
+        )

--- a/tui/internal/api/client.gen.go
+++ b/tui/internal/api/client.gen.go
@@ -65,6 +65,29 @@ const (
 	PartUpdatedTypePartUpdated PartUpdatedType = "part.updated"
 )
 
+// Defines values for PermissionAnswerReply.
+const (
+	Allow PermissionAnswerReply = "allow"
+	Deny  PermissionAnswerReply = "deny"
+)
+
+// Defines values for PermissionAnsweredType.
+const (
+	PermissionAnsweredTypePermissionAnswered PermissionAnsweredType = "permission.answered"
+)
+
+// Defines values for PermissionAskedType.
+const (
+	PermissionAskedTypePermissionAsked PermissionAskedType = "permission.asked"
+)
+
+// Defines values for PermissionRequestStatus.
+const (
+	PermissionRequestStatusAllowed PermissionRequestStatus = "allowed"
+	PermissionRequestStatusDenied  PermissionRequestStatus = "denied"
+	PermissionRequestStatusPending PermissionRequestStatus = "pending"
+)
+
 // Defines values for ReasoningPartType.
 const (
 	Reasoning ReasoningPartType = "reasoning"
@@ -134,7 +157,7 @@ const (
 
 // Defines values for ToolStatePendingStatus.
 const (
-	Pending ToolStatePendingStatus = "pending"
+	ToolStatePendingStatusPending ToolStatePendingStatus = "pending"
 )
 
 // Defines values for ToolStateRunningStatus.
@@ -330,9 +353,59 @@ type PartUpdated struct {
 // PartUpdatedType defines model for PartUpdated.Type.
 type PartUpdatedType string
 
+// PermissionAnswer Body of “POST /session/{id}/permissions/{permID}“.
+type PermissionAnswer struct {
+	Reply PermissionAnswerReply `json:"reply"`
+}
+
+// PermissionAnswerReply defines model for PermissionAnswer.Reply.
+type PermissionAnswerReply string
+
+// PermissionAnswered defines model for PermissionAnswered.
+type PermissionAnswered struct {
+	Id         *string                   `json:"id,omitempty"`
+	Properties UnderscorePermissionProps `json:"properties"`
+	Type       PermissionAnsweredType    `json:"type"`
+}
+
+// PermissionAnsweredType defines model for PermissionAnswered.Type.
+type PermissionAnsweredType string
+
+// PermissionAsked defines model for PermissionAsked.
+type PermissionAsked struct {
+	Id         *string                   `json:"id,omitempty"`
+	Properties UnderscorePermissionProps `json:"properties"`
+	Type       PermissionAskedType       `json:"type"`
+}
+
+// PermissionAskedType defines model for PermissionAsked.Type.
+type PermissionAskedType string
+
+// PermissionRequest One pending or answered ask, as persisted and streamed.
+type PermissionRequest struct {
+	Answered  *int                     `json:"answered"`
+	Created   int                      `json:"created"`
+	Id        string                   `json:"id"`
+	Metadata  *map[string]interface{}  `json:"metadata,omitempty"`
+	SessionId string                   `json:"sessionId"`
+	Status    *PermissionRequestStatus `json:"status,omitempty"`
+	Title     string                   `json:"title"`
+	Tool      string                   `json:"tool"`
+}
+
+// PermissionRequestStatus defines model for PermissionRequest.Status.
+type PermissionRequestStatus string
+
 // PromptRequest Body of “POST /session/{id}/message“.
 type PromptRequest struct {
 	Text string `json:"text"`
+}
+
+// ProviderInfo One supported LLM provider, as exposed by “GET /provider“.
+type ProviderInfo struct {
+	Active *bool     `json:"active,omitempty"`
+	Models *[]string `json:"models,omitempty"`
+	Name   string    `json:"name"`
 }
 
 // ReasoningPart defines model for ReasoningPart.
@@ -346,6 +419,15 @@ type ReasoningPart struct {
 
 // ReasoningPartType defines model for ReasoningPart.Type.
 type ReasoningPartType string
+
+// ServerConfigInfo Resolved server configuration, secrets redacted (“GET /config“).
+type ServerConfigInfo struct {
+	ApiKeyConfigured *bool   `json:"apiKeyConfigured,omitempty"`
+	BaseUrl          *string `json:"baseUrl"`
+	Model            *string `json:"model"`
+	Provider         *string `json:"provider"`
+	Version          string  `json:"version"`
+}
 
 // ServerConnected defines model for ServerConnected.
 type ServerConnected struct {
@@ -580,6 +662,12 @@ type PartProps_Part struct {
 	union json.RawMessage
 }
 
+// UnderscorePermissionProps defines model for _PermissionProps.
+type UnderscorePermissionProps struct {
+	// Request One pending or answered ask, as persisted and streamed.
+	Request PermissionRequest `json:"request"`
+}
+
 // UnderscoreSessionErrorProps defines model for _SessionErrorProps.
 type UnderscoreSessionErrorProps struct {
 	Error string `json:"error"`
@@ -605,6 +693,11 @@ type ListAgentsAgentGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// GetConfigConfigGetParams defines parameters for GetConfigConfigGet.
+type GetConfigConfigGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // EventsEventGetParams defines parameters for EventsEventGet.
 type EventsEventGetParams struct {
 	XSkeneDirectory *string `json:"x-skene-directory,omitempty"`
@@ -621,6 +714,11 @@ type GetJourneyJourneyGetParams struct {
 type AnalyseJourneyAnalysePostParams struct {
 	Authorization   *string `json:"authorization,omitempty"`
 	XSkeneDirectory *string `json:"x-skene-directory,omitempty"`
+}
+
+// ListProvidersProviderGetParams defines parameters for ListProvidersProviderGet.
+type ListProvidersProviderGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
 }
 
 // ListSessionsSessionGetParams defines parameters for ListSessionsSessionGet.
@@ -660,6 +758,16 @@ type PromptSessionSessionIdMessagePostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ListPermissionsSessionSessionIdPermissionsGetParams defines parameters for ListPermissionsSessionSessionIdPermissionsGet.
+type ListPermissionsSessionSessionIdPermissionsGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// AnswerPermissionSessionSessionIdPermissionsPermIdPostParams defines parameters for AnswerPermissionSessionSessionIdPermissionsPermIdPost.
+type AnswerPermissionSessionSessionIdPermissionsPermIdPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // AnalyseJourneyAnalysePostJSONRequestBody defines body for AnalyseJourneyAnalysePost for application/json ContentType.
 type AnalyseJourneyAnalysePostJSONRequestBody = JourneyAnalyseRequest
 
@@ -668,6 +776,9 @@ type CreateSessionSessionPostJSONRequestBody = SessionCreateRequest
 
 // PromptSessionSessionIdMessagePostJSONRequestBody defines body for PromptSessionSessionIdMessagePost for application/json ContentType.
 type PromptSessionSessionIdMessagePostJSONRequestBody = PromptRequest
+
+// AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody defines body for AnswerPermissionSessionSessionIdPermissionsPermIdPost for application/json ContentType.
+type AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody = PermissionAnswer
 
 // AsTokenUsage returns the union data inside the AssistantMessage_Tokens as a TokenUsage
 func (t AssistantMessage_Tokens) AsTokenUsage() (TokenUsage, error) {
@@ -985,6 +1096,62 @@ func (t *Event) MergePartUpdated(v PartUpdated) error {
 	return err
 }
 
+// AsPermissionAsked returns the union data inside the Event as a PermissionAsked
+func (t Event) AsPermissionAsked() (PermissionAsked, error) {
+	var body PermissionAsked
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPermissionAsked overwrites any union data inside the Event as the provided PermissionAsked
+func (t *Event) FromPermissionAsked(v PermissionAsked) error {
+	v.Type = "permission.asked"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePermissionAsked performs a merge with any union data inside the Event, using the provided PermissionAsked
+func (t *Event) MergePermissionAsked(v PermissionAsked) error {
+	v.Type = "permission.asked"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPermissionAnswered returns the union data inside the Event as a PermissionAnswered
+func (t Event) AsPermissionAnswered() (PermissionAnswered, error) {
+	var body PermissionAnswered
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPermissionAnswered overwrites any union data inside the Event as the provided PermissionAnswered
+func (t *Event) FromPermissionAnswered(v PermissionAnswered) error {
+	v.Type = "permission.answered"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePermissionAnswered performs a merge with any union data inside the Event, using the provided PermissionAnswered
+func (t *Event) MergePermissionAnswered(v PermissionAnswered) error {
+	v.Type = "permission.answered"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t Event) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -1007,6 +1174,10 @@ func (t Event) ValueByDiscriminator() (interface{}, error) {
 		return t.AsPartCreated()
 	case "part.updated":
 		return t.AsPartUpdated()
+	case "permission.answered":
+		return t.AsPermissionAnswered()
+	case "permission.asked":
+		return t.AsPermissionAsked()
 	case "server.connected":
 		return t.AsServerConnected()
 	case "server.heartbeat":
@@ -1917,6 +2088,9 @@ type ClientInterface interface {
 	// ListAgentsAgentGet request
 	ListAgentsAgentGet(ctx context.Context, params *ListAgentsAgentGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetConfigConfigGet request
+	GetConfigConfigGet(ctx context.Context, params *GetConfigConfigGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EventsEventGet request
 	EventsEventGet(ctx context.Context, params *EventsEventGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1930,6 +2104,9 @@ type ClientInterface interface {
 	AnalyseJourneyAnalysePostWithBody(ctx context.Context, params *AnalyseJourneyAnalysePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	AnalyseJourneyAnalysePost(ctx context.Context, params *AnalyseJourneyAnalysePostParams, body AnalyseJourneyAnalysePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProvidersProviderGet request
+	ListProvidersProviderGet(ctx context.Context, params *ListProvidersProviderGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListSessionsSessionGet request
 	ListSessionsSessionGet(ctx context.Context, params *ListSessionsSessionGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1955,10 +2132,30 @@ type ClientInterface interface {
 	PromptSessionSessionIdMessagePostWithBody(ctx context.Context, sessionId string, params *PromptSessionSessionIdMessagePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	PromptSessionSessionIdMessagePost(ctx context.Context, sessionId string, params *PromptSessionSessionIdMessagePostParams, body PromptSessionSessionIdMessagePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListPermissionsSessionSessionIdPermissionsGet request
+	ListPermissionsSessionSessionIdPermissionsGet(ctx context.Context, sessionId string, params *ListPermissionsSessionSessionIdPermissionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBody request with any body
+	AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBody(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AnswerPermissionSessionSessionIdPermissionsPermIdPost(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, body AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ListAgentsAgentGet(ctx context.Context, params *ListAgentsAgentGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListAgentsAgentGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetConfigConfigGet(ctx context.Context, params *GetConfigConfigGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetConfigConfigGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2019,6 +2216,18 @@ func (c *Client) AnalyseJourneyAnalysePostWithBody(ctx context.Context, params *
 
 func (c *Client) AnalyseJourneyAnalysePost(ctx context.Context, params *AnalyseJourneyAnalysePostParams, body AnalyseJourneyAnalysePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAnalyseJourneyAnalysePostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProvidersProviderGet(ctx context.Context, params *ListProvidersProviderGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProvidersProviderGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2137,6 +2346,42 @@ func (c *Client) PromptSessionSessionIdMessagePost(ctx context.Context, sessionI
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListPermissionsSessionSessionIdPermissionsGet(ctx context.Context, sessionId string, params *ListPermissionsSessionSessionIdPermissionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListPermissionsSessionSessionIdPermissionsGetRequest(c.Server, sessionId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBody(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequestWithBody(c.Server, sessionId, permId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AnswerPermissionSessionSessionIdPermissionsPermIdPost(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, body AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequest(c.Server, sessionId, permId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // NewListAgentsAgentGetRequest generates requests for ListAgentsAgentGet
 func NewListAgentsAgentGetRequest(server string, params *ListAgentsAgentGetParams) (*http.Request, error) {
 	var err error
@@ -2147,6 +2392,48 @@ func NewListAgentsAgentGetRequest(server string, params *ListAgentsAgentGetParam
 	}
 
 	operationPath := fmt.Sprintf("/agent")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewGetConfigConfigGetRequest generates requests for GetConfigConfigGet
+func NewGetConfigConfigGetRequest(server string, params *GetConfigConfigGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/config")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2371,6 +2658,48 @@ func NewAnalyseJourneyAnalysePostRequestWithBody(server string, params *AnalyseJ
 			}
 
 			req.Header.Set("x-skene-directory", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListProvidersProviderGetRequest generates requests for ListProvidersProviderGet
+func NewListProvidersProviderGetRequest(server string, params *ListProvidersProviderGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/provider")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
 		}
 
 	}
@@ -2755,6 +3084,124 @@ func NewPromptSessionSessionIdMessagePostRequestWithBody(server string, sessionI
 	return req, nil
 }
 
+// NewListPermissionsSessionSessionIdPermissionsGetRequest generates requests for ListPermissionsSessionSessionIdPermissionsGet
+func NewListPermissionsSessionSessionIdPermissionsGetRequest(server string, sessionId string, params *ListPermissionsSessionSessionIdPermissionsGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/session/%s/permissions", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequest calls the generic AnswerPermissionSessionSessionIdPermissionsPermIdPost builder with application/json body
+func NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequest(server string, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, body AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequestWithBody(server, sessionId, permId, params, "application/json", bodyReader)
+}
+
+// NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequestWithBody generates requests for AnswerPermissionSessionSessionIdPermissionsPermIdPost with any type of body
+func NewAnswerPermissionSessionSessionIdPermissionsPermIdPostRequestWithBody(server string, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "perm_id", runtime.ParamLocationPath, permId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/session/%s/permissions/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -2801,6 +3248,9 @@ type ClientWithResponsesInterface interface {
 	// ListAgentsAgentGetWithResponse request
 	ListAgentsAgentGetWithResponse(ctx context.Context, params *ListAgentsAgentGetParams, reqEditors ...RequestEditorFn) (*ListAgentsAgentGetResponse, error)
 
+	// GetConfigConfigGetWithResponse request
+	GetConfigConfigGetWithResponse(ctx context.Context, params *GetConfigConfigGetParams, reqEditors ...RequestEditorFn) (*GetConfigConfigGetResponse, error)
+
 	// EventsEventGetWithResponse request
 	EventsEventGetWithResponse(ctx context.Context, params *EventsEventGetParams, reqEditors ...RequestEditorFn) (*EventsEventGetResponse, error)
 
@@ -2814,6 +3264,9 @@ type ClientWithResponsesInterface interface {
 	AnalyseJourneyAnalysePostWithBodyWithResponse(ctx context.Context, params *AnalyseJourneyAnalysePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnalyseJourneyAnalysePostResponse, error)
 
 	AnalyseJourneyAnalysePostWithResponse(ctx context.Context, params *AnalyseJourneyAnalysePostParams, body AnalyseJourneyAnalysePostJSONRequestBody, reqEditors ...RequestEditorFn) (*AnalyseJourneyAnalysePostResponse, error)
+
+	// ListProvidersProviderGetWithResponse request
+	ListProvidersProviderGetWithResponse(ctx context.Context, params *ListProvidersProviderGetParams, reqEditors ...RequestEditorFn) (*ListProvidersProviderGetResponse, error)
 
 	// ListSessionsSessionGetWithResponse request
 	ListSessionsSessionGetWithResponse(ctx context.Context, params *ListSessionsSessionGetParams, reqEditors ...RequestEditorFn) (*ListSessionsSessionGetResponse, error)
@@ -2839,6 +3292,14 @@ type ClientWithResponsesInterface interface {
 	PromptSessionSessionIdMessagePostWithBodyWithResponse(ctx context.Context, sessionId string, params *PromptSessionSessionIdMessagePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PromptSessionSessionIdMessagePostResponse, error)
 
 	PromptSessionSessionIdMessagePostWithResponse(ctx context.Context, sessionId string, params *PromptSessionSessionIdMessagePostParams, body PromptSessionSessionIdMessagePostJSONRequestBody, reqEditors ...RequestEditorFn) (*PromptSessionSessionIdMessagePostResponse, error)
+
+	// ListPermissionsSessionSessionIdPermissionsGetWithResponse request
+	ListPermissionsSessionSessionIdPermissionsGetWithResponse(ctx context.Context, sessionId string, params *ListPermissionsSessionSessionIdPermissionsGetParams, reqEditors ...RequestEditorFn) (*ListPermissionsSessionSessionIdPermissionsGetResponse, error)
+
+	// AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBodyWithResponse request with any body
+	AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBodyWithResponse(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse, error)
+
+	AnswerPermissionSessionSessionIdPermissionsPermIdPostWithResponse(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, body AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse, error)
 }
 
 type ListAgentsAgentGetResponse struct {
@@ -2858,6 +3319,29 @@ func (r ListAgentsAgentGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListAgentsAgentGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetConfigConfigGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ServerConfigInfo
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetConfigConfigGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetConfigConfigGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2948,6 +3432,29 @@ func (r AnalyseJourneyAnalysePostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r AnalyseJourneyAnalysePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListProvidersProviderGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]ProviderInfo
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProvidersProviderGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProvidersProviderGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3117,6 +3624,52 @@ func (r PromptSessionSessionIdMessagePostResponse) StatusCode() int {
 	return 0
 }
 
+type ListPermissionsSessionSessionIdPermissionsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]PermissionRequest
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListPermissionsSessionSessionIdPermissionsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListPermissionsSessionSessionIdPermissionsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PermissionRequest
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // ListAgentsAgentGetWithResponse request returning *ListAgentsAgentGetResponse
 func (c *ClientWithResponses) ListAgentsAgentGetWithResponse(ctx context.Context, params *ListAgentsAgentGetParams, reqEditors ...RequestEditorFn) (*ListAgentsAgentGetResponse, error) {
 	rsp, err := c.ListAgentsAgentGet(ctx, params, reqEditors...)
@@ -3124,6 +3677,15 @@ func (c *ClientWithResponses) ListAgentsAgentGetWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseListAgentsAgentGetResponse(rsp)
+}
+
+// GetConfigConfigGetWithResponse request returning *GetConfigConfigGetResponse
+func (c *ClientWithResponses) GetConfigConfigGetWithResponse(ctx context.Context, params *GetConfigConfigGetParams, reqEditors ...RequestEditorFn) (*GetConfigConfigGetResponse, error) {
+	rsp, err := c.GetConfigConfigGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetConfigConfigGetResponse(rsp)
 }
 
 // EventsEventGetWithResponse request returning *EventsEventGetResponse
@@ -3168,6 +3730,15 @@ func (c *ClientWithResponses) AnalyseJourneyAnalysePostWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseAnalyseJourneyAnalysePostResponse(rsp)
+}
+
+// ListProvidersProviderGetWithResponse request returning *ListProvidersProviderGetResponse
+func (c *ClientWithResponses) ListProvidersProviderGetWithResponse(ctx context.Context, params *ListProvidersProviderGetParams, reqEditors ...RequestEditorFn) (*ListProvidersProviderGetResponse, error) {
+	rsp, err := c.ListProvidersProviderGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProvidersProviderGetResponse(rsp)
 }
 
 // ListSessionsSessionGetWithResponse request returning *ListSessionsSessionGetResponse
@@ -3249,6 +3820,32 @@ func (c *ClientWithResponses) PromptSessionSessionIdMessagePostWithResponse(ctx 
 	return ParsePromptSessionSessionIdMessagePostResponse(rsp)
 }
 
+// ListPermissionsSessionSessionIdPermissionsGetWithResponse request returning *ListPermissionsSessionSessionIdPermissionsGetResponse
+func (c *ClientWithResponses) ListPermissionsSessionSessionIdPermissionsGetWithResponse(ctx context.Context, sessionId string, params *ListPermissionsSessionSessionIdPermissionsGetParams, reqEditors ...RequestEditorFn) (*ListPermissionsSessionSessionIdPermissionsGetResponse, error) {
+	rsp, err := c.ListPermissionsSessionSessionIdPermissionsGet(ctx, sessionId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListPermissionsSessionSessionIdPermissionsGetResponse(rsp)
+}
+
+// AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBodyWithResponse request with arbitrary body returning *AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse
+func (c *ClientWithResponses) AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBodyWithResponse(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse, error) {
+	rsp, err := c.AnswerPermissionSessionSessionIdPermissionsPermIdPostWithBody(ctx, sessionId, permId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnswerPermissionSessionSessionIdPermissionsPermIdPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) AnswerPermissionSessionSessionIdPermissionsPermIdPostWithResponse(ctx context.Context, sessionId string, permId string, params *AnswerPermissionSessionSessionIdPermissionsPermIdPostParams, body AnswerPermissionSessionSessionIdPermissionsPermIdPostJSONRequestBody, reqEditors ...RequestEditorFn) (*AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse, error) {
+	rsp, err := c.AnswerPermissionSessionSessionIdPermissionsPermIdPost(ctx, sessionId, permId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnswerPermissionSessionSessionIdPermissionsPermIdPostResponse(rsp)
+}
+
 // ParseListAgentsAgentGetResponse parses an HTTP response from a ListAgentsAgentGetWithResponse call
 func ParseListAgentsAgentGetResponse(rsp *http.Response) (*ListAgentsAgentGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -3265,6 +3862,39 @@ func ParseListAgentsAgentGetResponse(rsp *http.Response) (*ListAgentsAgentGetRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []AgentInfo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetConfigConfigGetResponse parses an HTTP response from a GetConfigConfigGetWithResponse call
+func ParseGetConfigConfigGetResponse(rsp *http.Response) (*GetConfigConfigGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetConfigConfigGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ServerConfigInfo
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3387,6 +4017,39 @@ func ParseAnalyseJourneyAnalysePostResponse(rsp *http.Response) (*AnalyseJourney
 			return nil, err
 		}
 		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProvidersProviderGetResponse parses an HTTP response from a ListProvidersProviderGetWithResponse call
+func ParseListProvidersProviderGetResponse(rsp *http.Response) (*ListProvidersProviderGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProvidersProviderGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []ProviderInfo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
@@ -3620,6 +4283,72 @@ func ParsePromptSessionSessionIdMessagePostResponse(rsp *http.Response) (*Prompt
 			return nil, err
 		}
 		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListPermissionsSessionSessionIdPermissionsGetResponse parses an HTTP response from a ListPermissionsSessionSessionIdPermissionsGetWithResponse call
+func ParseListPermissionsSessionSessionIdPermissionsGetResponse(rsp *http.Response) (*ListPermissionsSessionSessionIdPermissionsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListPermissionsSessionSessionIdPermissionsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []PermissionRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAnswerPermissionSessionSessionIdPermissionsPermIdPostResponse parses an HTTP response from a AnswerPermissionSessionSessionIdPermissionsPermIdPostWithResponse call
+func ParseAnswerPermissionSessionSessionIdPermissionsPermIdPostResponse(rsp *http.Response) (*AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AnswerPermissionSessionSessionIdPermissionsPermIdPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PermissionRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError

--- a/tui/internal/api/openapi.json
+++ b/tui/internal/api/openapi.json
@@ -424,6 +424,135 @@
         }
       }
     },
+    "/session/{session_id}/permissions": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "summary": "List Permissions",
+        "description": "Every permission request the session has raised, pending first-created first.",
+        "operationId": "list_permissions_session__session_id__permissions_get",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PermissionRequest"
+                  },
+                  "title": "Response List Permissions Session  Session Id  Permissions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/session/{session_id}/permissions/{perm_id}": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "summary": "Answer Permission",
+        "description": "Answer a pending ask; the paused tool handler resumes with the verdict.",
+        "operationId": "answer_permission_session__session_id__permissions__perm_id__post",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "perm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Perm Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermissionAnswer"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionRequest"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/event": {
       "get": {
         "tags": [
@@ -629,6 +758,98 @@
                     "$ref": "#/components/schemas/AgentInfo"
                   },
                   "title": "Response List Agents Agent Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/config": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get Config",
+        "description": "The server's resolved LLM configuration, secrets redacted.",
+        "operationId": "get_config_config_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerConfigInfo"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/provider": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List Providers",
+        "description": "Supported LLM providers; ``active`` marks the one the server runs with.",
+        "operationId": "list_providers_provider_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderInfo"
+                  },
+                  "title": "Response List Providers Provider Get"
                 }
               }
             }
@@ -1114,6 +1335,80 @@
         "title": "MilestonePart",
         "description": "A candidate milestone emitted by an analysis agent's ``emit_milestone``.\n\nStreams live from subagent runs \u2014 ``milestone.stage_id`` is still\n``None`` at this point; classification happens later in\n``finalize_journey`` and is only visible in the ``journey.yaml``\nartifact, not retroactively on these parts."
       },
+      "PermissionAnswer": {
+        "properties": {
+          "reply": {
+            "type": "string",
+            "enum": [
+              "allow",
+              "deny"
+            ],
+            "title": "Reply"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "reply"
+        ],
+        "title": "PermissionAnswer",
+        "description": "Body of ``POST /session/{id}/permissions/{permID}``."
+      },
+      "PermissionRequest": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "sessionId": {
+            "type": "string",
+            "title": "Sessionid"
+          },
+          "tool": {
+            "type": "string",
+            "title": "Tool"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "allowed",
+              "denied"
+            ],
+            "title": "Status",
+            "default": "pending"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "answered": {
+            "title": "Answered",
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "created",
+          "id",
+          "sessionId",
+          "title",
+          "tool"
+        ],
+        "title": "PermissionRequest",
+        "description": "One pending or answered ask, as persisted and streamed."
+      },
       "PromptRequest": {
         "properties": {
           "text": {
@@ -1129,6 +1424,33 @@
         ],
         "title": "PromptRequest",
         "description": "Body of ``POST /session/{id}/message``."
+      },
+      "ProviderInfo": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "models": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Models"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "ProviderInfo",
+        "description": "One supported LLM provider, as exposed by ``GET /provider``."
       },
       "ReasoningPart": {
         "properties": {
@@ -1167,6 +1489,41 @@
           "type"
         ],
         "title": "ReasoningPart"
+      },
+      "ServerConfigInfo": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string",
+            "nullable": true
+          },
+          "model": {
+            "title": "Model",
+            "type": "string",
+            "nullable": true
+          },
+          "baseUrl": {
+            "title": "Baseurl",
+            "type": "string",
+            "nullable": true
+          },
+          "apiKeyConfigured": {
+            "type": "boolean",
+            "title": "Apikeyconfigured",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "title": "ServerConfigInfo",
+        "description": "Resolved server configuration, secrets redacted (``GET /config``)."
       },
       "Session": {
         "properties": {
@@ -1718,6 +2075,58 @@
         "title": "PartUpdated",
         "type": "object"
       },
+      "PermissionAnswered": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "type": {
+            "default": "permission.answered",
+            "title": "Type",
+            "type": "string",
+            "enum": [
+              "permission.answered"
+            ]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/_PermissionProps"
+          }
+        },
+        "required": [
+          "properties",
+          "type"
+        ],
+        "title": "PermissionAnswered",
+        "type": "object"
+      },
+      "PermissionAsked": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "type": {
+            "default": "permission.asked",
+            "title": "Type",
+            "type": "string",
+            "enum": [
+              "permission.asked"
+            ]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/_PermissionProps"
+          }
+        },
+        "required": [
+          "properties",
+          "type"
+        ],
+        "title": "PermissionAsked",
+        "type": "object"
+      },
       "ServerConnected": {
         "additionalProperties": false,
         "properties": {
@@ -1956,6 +2365,19 @@
         "title": "_PartProps",
         "type": "object"
       },
+      "_PermissionProps": {
+        "additionalProperties": false,
+        "properties": {
+          "request": {
+            "$ref": "#/components/schemas/PermissionRequest"
+          }
+        },
+        "required": [
+          "request"
+        ],
+        "title": "_PermissionProps",
+        "type": "object"
+      },
       "_SessionErrorProps": {
         "additionalProperties": false,
         "properties": {
@@ -1994,6 +2416,8 @@
             "message.updated": "#/components/schemas/MessageUpdated",
             "part.created": "#/components/schemas/PartCreated",
             "part.updated": "#/components/schemas/PartUpdated",
+            "permission.answered": "#/components/schemas/PermissionAnswered",
+            "permission.asked": "#/components/schemas/PermissionAsked",
             "server.connected": "#/components/schemas/ServerConnected",
             "server.heartbeat": "#/components/schemas/ServerHeartbeat",
             "session.created": "#/components/schemas/SessionCreated",
@@ -2033,6 +2457,12 @@
           },
           {
             "$ref": "#/components/schemas/PartUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/PermissionAsked"
+          },
+          {
+            "$ref": "#/components/schemas/PermissionAnswered"
           }
         ]
       }

--- a/tui/internal/api/sse.go
+++ b/tui/internal/api/sse.go
@@ -51,6 +51,10 @@ func (e EventEnvelope) Decode() (interface{}, error) {
 		target = &PartCreated{}
 	case "part.updated":
 		target = &PartUpdated{}
+	case "permission.asked":
+		target = &PermissionAsked{}
+	case "permission.answered":
+		target = &PermissionAnswered{}
 	default:
 		return nil, nil
 	}

--- a/tui/internal/api/sse_test.go
+++ b/tui/internal/api/sse_test.go
@@ -81,9 +81,33 @@ func TestDecodeSessionEvent(t *testing.T) {
 }
 
 func TestDecodeUnknownTypeIsNil(t *testing.T) {
-	decoded, err := EventEnvelope{Type: "permission.asked", Raw: []byte(`{}`)}.Decode()
+	decoded, err := EventEnvelope{Type: "session.hibernated", Raw: []byte(`{}`)}.Decode()
 	if err != nil || decoded != nil {
 		t.Fatalf("unknown types should be (nil, nil); got (%v, %v)", decoded, err)
+	}
+}
+
+func TestDecodePermissionAsked(t *testing.T) {
+	envelope := EventEnvelope{
+		Type: "permission.asked",
+		Raw: []byte(`{"id":"evt_5","type":"permission.asked","properties":{"request":{` +
+			`"id":"prm_1","sessionId":"ses_1","tool":"write_db","title":"Write to users?",` +
+			`"metadata":{},"status":"pending","created":1,"answered":null}}}`),
+	}
+	decoded, err := envelope.Decode()
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	event, ok := decoded.(*PermissionAsked)
+	if !ok {
+		t.Fatalf("expected *PermissionAsked, got %T", decoded)
+	}
+	request := event.Properties.Request
+	if request.Id != "prm_1" || request.Tool != "write_db" {
+		t.Fatalf("unexpected request contents: %+v", request)
+	}
+	if request.Status == nil || *request.Status != PermissionRequestStatusPending {
+		t.Fatalf("expected pending status, got %v", request.Status)
 	}
 }
 


### PR DESCRIPTION
Phase 5 of the backend-server plan (`docs/design/backend-server.md`): hardening & growth. Closes out the phased rearchitecture — all five phases are now implemented.

## Permission ask flow

- `PermissionRequest` / `PermissionAnswer` wire models, `permission.asked` / `permission.answered` in the `Event` union, `permission_request` table.
- `core/permissions.py::PermissionService`: a tool handler calls `ask()` and suspends until a client answers via `POST /session/{id}/permissions/{permID}`; `GET /session/{id}/permissions` lists a session's asks.
- Deliberate semantics: no rulesets (every ask goes to the client), no timeout (pending until answered or aborted), one-shot answers (second answer → 409), aborted runs record pending asks as denied.
- Tools reach the service by closure via `JourneyRunContext.permissions`; the agent loop stays permission-free. No built-in tool asks yet — the journey toolset is read-only; the first db-write tool is the intended consumer.
- TUI: `sse.go` decodes both events (client regenerated); the ask UI itself is deferred until a tool that asks ships.

## Config / provider surface

- `GET /config` → startup-resolved snapshot (`ServerConfigInfo`; API key exposed only as a boolean).
- `GET /provider` → supported-provider catalog with the active one marked.
- Read-only by decision: no `PATCH /config` — changing config means restarting `skene serve` (rebuilding the LLM factory mid-flight while runs are in progress buys nothing).

## Per-agent model overrides

- `SessionService.resolve_llm(model)` passes `model=` to any `llm_factory` accepting that keyword; `skene serve`'s factory opts in.
- The task tool resolves a fresh client for subagents with `AgentDef.model` set; `start_journey_run` honours the primary's. The embedded CLI's pinned client deliberately ignores overrides.

## Remote serving (`skene attach`)

- `skene attach <url> [--token]` verifies `/health` and persists `server_url` / `server_token` in `.skene.config` (`--clear` detaches).
- `analyse-journey` (via attached config, `--server`, or `SKENE_SERVER_URL`) runs against the remote server through a new Python SSE client (`cli/remote.py`): subscribes to `/event` before POSTing (no missed progress), renders the same status lines as the embedded run, Ctrl-C aborts the remote session tree. No local LLM credentials needed in remote mode; request paths are interpreted server-side.

## Testing

- 495 Python tests pass (new: permission service/routes, config/provider routes, model-override resolution, attach config persistence, run tracker, and an end-to-end remote run against a real uvicorn socket — ASGITransport buffers SSE, per the phase-2 note).
- Go: `go build ./...` + TUI test suites pass after client regen.
- Live smoke: `skene serve` → `skene attach` → remote `analyse-journey` with streamed subagent progress and error surfacing.

Design doc updated: status table, API-surface list, and a "Phase 5 — as built" hand-off section (including what stays deferred: token streaming, TUI ask UI, legacy uvx command ports, CI client-regen job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
