### PR TITLE
docs: document the client/server rearchitecture (phases 1-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Both the Python CLI and the TUI write artifacts to a single bundle directory in 
 | `cursor-plugin/` | Cursor IDE plugin | — | — |
 | `skills/` | Skene Skills — composable backend schemas for Supabase | SQL | [npm](https://www.npmjs.com/package/@skene/database-skills) |
 
-The TUI (`tui/`) is a Bubble Tea app that provides an interactive wizard experience and orchestrates the Python CLI via `uvx`. Each package has independent CI/CD pipelines.
+The TUI (`tui/`) is a Bubble Tea app that provides an interactive wizard experience. For journey analysis it runs the Python backend as a server (`skene serve`) and renders its event stream; legacy commands run via `uvx`. Each package has independent CI/CD pipelines.
 
 ## Contributing
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -82,7 +82,7 @@ uvx skene build
 uvx skene push
 ```
 
-> **Note:** If you run **journey analysis from the TUI** while linked to a workspace, your `journey.yaml` is published to Skene Cloud automatically on first run — no manual `push` needed for the journey to appear in the cloud canvas. The `build → push` flow above is still how you deploy engine artifacts and Supabase triggers. See [Automatic first publish](../guides/push.md#automatic-first-publish-journey-analysis).
+> **Note:** Journey analysis never publishes anything by itself. To get your `journey.yaml` into the cloud Customer Journey canvas, push it — from the TUI use the explicit **"Deploy to Skene Cloud"** step, from the CLI run `skene push`. The `build → push` flow above is also how you deploy engine artifacts and Supabase triggers.
 
 ## What you get
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -66,6 +66,8 @@ Displays all current configuration values and their sources.
 | `debug` | boolean | `false` | Show diagnostic messages and log LLM I/O to `~/.local/state/skene/debug/` |
 | `exclude_folders` | list | `[]` | Folder names to exclude from analysis |
 | `upstream` | string | — | Upstream workspace URL for `push` command |
+| `server_url` | string | — | URL of a remote `skene serve` instance. Written by `skene attach`; used by `analyse-journey` remote mode. |
+| `server_token` | string | — | Bearer token for the remote server. Written by `skene attach`. |
 
 ### Sticky output directory
 
@@ -124,8 +126,19 @@ exclude_folders = ["tests", "vendor"]
 | `SKENE_DEBUG` | Enable debug mode | `true` |
 | `SKENE_UPSTREAM_API_KEY` | API key for upstream authentication | `sk-upstream-...` |
 | `SKENE_DB_URL` | PostgreSQL connection string for `analyse-journey` live schema introspection. Skene introspects all user-defined schemas (excluding `pg_catalog`, `information_schema`, `pg_toast`, and `pg_*` schemas). | `postgresql://user:pass@localhost:5432/mydb` |
+| `SKENE_SERVER_URL` | URL of a remote `skene serve` instance for `analyse-journey` (equivalent to `--server`) | `http://127.0.0.1:4906` |
+| `SKENE_SERVER_TOKEN` | Bearer token for server auth (`serve --token`, `attach --token`, `analyse-journey --server-token`) | `my-secret` |
+| `SKENE_DB_PATH` | Path to the global SQLite session database (see below) | `~/.local/share/skene/skene.db` |
 | `LMSTUDIO_BASE_URL` | LM Studio server URL | `http://localhost:1234/v1` |
 | `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434/v1` |
+
+## Server settings
+
+`skene attach <url>` connects the CLI to a running [`skene serve`](../reference/cli.md#serve) instance: it verifies the server's `/health` and saves `server_url` / `server_token` to `.skene.config` (the project config if one exists, otherwise the user config). Once attached, `analyse-journey` runs on that server. `skene attach --clear` removes the settings.
+
+## Session database
+
+Every `analyse-journey` run — embedded or served — persists a session trace in a global SQLite database at `~/.local/share/skene/skene.db`. Override the location with `SKENE_DB_PATH` or `skene serve --db-path`. The database holds sessions for every workspace on the machine; nothing is deleted automatically.
 
 ## Upstream credentials
 

--- a/docs/guides/push.md
+++ b/docs/guides/push.md
@@ -59,13 +59,9 @@ uvx skene push --upstream https://skene.ai/workspace/my-app
 
 Trigger SQL is produced by `build` for engine features that define `action`.
 
-## Automatic first publish (journey analysis)
+## Publishing a journey from the TUI
 
-You don't always need an explicit `push` for a **journey** to reach Skene Cloud. When you run journey analysis from the **TUI** while linked to a workspace (the `skene` provider), Skene publishes the generated `journey.yaml` automatically — but only when the workspace has **no journey upstream yet**. This is so a first-time user's journey appears in the cloud Customer Journey canvas without a manual step.
-
-- If a journey already exists upstream, nothing is published (your existing journey is never overwritten).
-- If the presence check can't be completed, publishing is skipped silently.
-- A normal `skene push` still uploads the full bundle (engine, registry, migrations, journey) as described above.
+Running journey analysis (from the TUI or the CLI) never publishes anything by itself — the journey reaches Skene Cloud only when you push. In the TUI that is the explicit **"Deploy to Skene Cloud"** step, which runs a normal `skene push` and uploads the full bundle (engine, registry, migrations, journey) as described above.
 
 ## Upstream authentication
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ A CLI toolkit for analyzing codebases through the lens of Product-Led Growth (PL
 - **Builds implementation artifacts and prompts** — updates `skene-context/engine.yaml`, feature-registry, trigger SQL, and generates implementation prompts
 - **Pushes the Skene bundle upstream** — uploads files from the configured output directory plus the latest trigger migration to Skene Cloud
 - **Validates engine/migration alignment** — checks action-enabled engine features against generated SQL artifacts
+- **Maps the customer journey** — `analyse-journey` uses parallel code and schema agents to produce a `journey.yaml` of your product's user lifecycle
+- **Runs as a client/server system** — a backend server (`skene serve`) owns the analysis engine and exposes an [HTTP API](reference/http-api.md); the CLI and TUI are clients, and every run is persisted as a session trace
 - **Supports multiple LLM providers**: OpenAI, Gemini, Anthropic, LM Studio, Ollama, and any OpenAI-compatible endpoint
 
 ## Core workflow
@@ -77,6 +79,7 @@ uvx skene push
 ### Reference
 
 - [CLI reference](reference/cli.md) — All commands and flags
+- [HTTP API](reference/http-api.md) — The `skene serve` REST + SSE API, domain model, and event stream
 - [Python API](reference/python-api.md) — CodebaseExplorer, analyzers, schemas
 - [Manifest schema](reference/manifest-schema.md) — JSON schema for v1.0 and v2.0 manifests
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -48,8 +48,15 @@ skene validate MANIFEST
    Validate a growth-manifest.json against the schema.
 
 skene analyse-journey [PATH]
-   Generate a journey.yaml describing the user lifecycle using parallel code and schema agents.
-    Flags: --schema-dir, --db-url (PostgreSQL DSN, also SKENE_DB_URL env var; introspects all user schemas excluding pg_catalog, information_schema, pg_toast, pg_*), -o/--output, --product-name, --api-key, -p/--provider, -m/--model, --base-url, --schema-max-turns, --code-max-turns, --classify-concurrency, --no-specialize, -q/--quiet, --debug, --no-fallback
+   Generate a journey.yaml describing the user lifecycle using parallel code and schema agents (main agent + subagents, run through an embedded server; every run persists a session trace in the skene DB).
+    Flags: --schema-dir, --db-url (PostgreSQL DSN, also SKENE_DB_URL env var; introspects all user schemas excluding pg_catalog, information_schema, pg_toast, pg_*), -o/--output, --product-name, --api-key, -p/--provider, -m/--model, --base-url, --server (remote skene serve URL, also SKENE_SERVER_URL; paths then resolve on the server's filesystem), --server-token (also SKENE_SERVER_TOKEN), --schema-max-turns, --code-max-turns, --classify-concurrency, --no-specialize, -q/--quiet, --debug, --no-fallback
+
+skene serve
+   Run the backend server headless (FastAPI; REST + SSE at http://127.0.0.1:4906 by default; OpenAPI at /doc). Starts without LLM credentials (analyse requests return 503). Persists sessions to a global SQLite DB.
+    Flags: --host (default 127.0.0.1; non-localhost requires --token), --port (default 4906), --token (also SKENE_SERVER_TOKEN; clients send Authorization: Bearer), --db-path (also SKENE_DB_PATH; default ~/.local/share/skene/skene.db), --api-key, -p/--provider, -m/--model, --base-url, -q/--quiet, --debug
+
+skene attach <URL> [--token] | --clear
+   Attach the CLI to a running skene serve (verifies /health, saves server_url/server_token to .skene.config). Once attached, analyse-journey runs on that server. --clear detaches.
 
 ## LLM Providers
 
@@ -67,9 +74,9 @@ File: .skene.config (TOML, project-level)
 File: ~/.config/skene/config (TOML, user-level)
 Priority: user config < project config < env vars < CLI flags
 
-Options: api_key, provider, model, base_url, output_dir, debug, exclude_folders, upstream
+Options: api_key, provider, model, base_url, output_dir, debug, exclude_folders, upstream, server_url, server_token (last two written by skene attach)
 
-Environment variables: SKENE_API_KEY, SKENE_PROVIDER, SKENE_BASE_URL, SKENE_OUTPUT_DIR, SKENE_DEBUG, SKENE_UPSTREAM_API_KEY, SKENE_DB_URL, LMSTUDIO_BASE_URL, OLLAMA_BASE_URL
+Environment variables: SKENE_API_KEY, SKENE_PROVIDER, SKENE_BASE_URL, SKENE_OUTPUT_DIR, SKENE_DEBUG, SKENE_UPSTREAM_API_KEY, SKENE_DB_URL, SKENE_SERVER_URL, SKENE_SERVER_TOKEN, SKENE_DB_PATH, LMSTUDIO_BASE_URL, OLLAMA_BASE_URL
 
 ## Output Files
 
@@ -81,6 +88,11 @@ growth-plan.md — Actionable plan with 3-5 growth loops, implementation roadmap
 skene-context/engine.yaml — Engine model with subjects + features merged by key
 feature-registry.json — Persistent feature registry tracking features across analysis runs
 product-docs.md — User-facing feature documentation (with --product-docs flag)
+journey.yaml — Customer journey map across seven lifecycle stages (analyse-journey)
+
+## HTTP API (skene serve)
+
+REST + SSE, workspace-scoped via x-skene-directory header. Routes: GET /event (SSE), POST/GET /session, GET /session/{id}[/children|/message|/permissions], POST /session/{id}/message (202 async), POST /session/{id}/abort, POST /session/{id}/permissions/{permID}, GET /agent, GET /provider, GET /config, POST /journey/analyse (202 {sessionId}), GET /journey, GET /health (unauthenticated). Full spec at /doc.
 
 ## Key Concepts
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,7 +63,9 @@ See the [analyze guide](../guides/analyze.md) for detailed usage.
 
 Generate a `journey.yaml` describing the user lifecycle of a product.
 
-Uses two parallel LLM agents — one analyzing the codebase filesystem, one analyzing the database schema — to discover user-facing milestones and assemble them into a validated Customer Journey map across seven lifecycle stages: discovery, onboarding, activation, engagement, retention, expansion, and virality.
+A main "skene" agent orchestrates two parallel subagents — one analyzing the codebase filesystem, one analyzing the database schema — to discover user-facing milestones; a deterministic finalize step merges and classifies them into a validated Customer Journey map across seven lifecycle stages: discovery, onboarding, activation, engagement, retention, expansion, and virality.
+
+By default the command runs an embedded (in-process) server; after [`skene attach`](#attach) (or with `--server`) it drives a remote [`skene serve`](#serve) instance instead. Every run — local or remote — persists a session trace in the [skene database](#serve), which is the debug trail for a run.
 
 ```
 skene analyse-journey [PATH] [OPTIONS]
@@ -87,6 +89,8 @@ skene analyse-journey [PATH] [OPTIONS]
 | `--provider TEXT` | `-p` | config value | LLM provider: `openai`, `gemini`, `anthropic`/`claude`, `lmstudio`, `ollama`, `generic`, `skene` |
 | `--model TEXT` | `-m` | provider default | LLM model name |
 | `--base-url TEXT` | | `$SKENE_BASE_URL` or config | Base URL for API endpoint |
+| `--server TEXT` | | `$SKENE_SERVER_URL`, or the URL saved by `skene attach` | Run the analysis on a remote `skene serve` instance instead of the embedded server. See [Remote mode](#remote-mode) below. |
+| `--server-token TEXT` | | `$SKENE_SERVER_TOKEN`, or the token saved by `skene attach` | Bearer token for the remote server |
 | `--schema-max-turns INT` | | `150` | Maximum agent turns for the schema agent (range: 1–500) |
 | `--code-max-turns INT` | | `200` | Maximum agent turns for the code agent (range: 1–500) |
 | `--classify-concurrency INT` | | `8` | Parallel classifier requests (range: 1–64) |
@@ -104,14 +108,90 @@ The schema agent requires one of two inputs — **never both**:
 
 `--schema-dir` and `--db-url` are mutually exclusive. At least one of `PATH`, `--schema-dir`, or `--db-url` must be provided. When `PATH` is omitted, only the schema agent runs (no code agent).
 
+### Remote mode
+
+When a server URL is set — via `--server`, `SKENE_SERVER_URL`, or a prior `skene attach` — the analysis runs on that server instead of in-process:
+
+- No local LLM credentials are needed; the server uses its own LLM configuration (`--api-key`/`--provider`/`--model`/`--base-url` are not forwarded).
+- Progress streams live from the server, and `Ctrl-C` aborts the remote run.
+- **Paths (`PATH`, `--schema-dir`, `--output`) are interpreted on the server's filesystem**, not the client's.
+
 ### Behavior notes
 
-- Requires a configured LLM (API key + provider). Local providers (`lmstudio`, `ollama`, `generic`) do not require an API key.
+- In local (embedded) mode, requires a configured LLM (API key + provider). Local providers (`lmstudio`, `ollama`, `generic`) do not require an API key.
 - The `generic` provider requires `--base-url`.
 - When `--db-url` is used without `--product-name`, the database name is extracted from the connection string for the product name.
-- When run from the TUI with a linked Skene Cloud workspace, the journey is automatically published on first run.
+- `--db-url` credentials are used live and never persisted; anything stored or streamed shows a redacted form.
+- Every run persists a session trace (agent turns, tool calls, milestones) in the skene database — use it to debug a run. See [`serve`](#serve) for the database location.
 
 See the CLI help output (`skene analyse-journey --help`) for detailed usage.
+
+---
+
+## `serve`
+
+Run the skene backend server headless.
+
+The server owns the analysis engine: it exposes the [HTTP API](http-api.md) (sessions, SSE event stream, journey analysis), and persists every run as a session tree in a global SQLite database. The CLI and the TUI are clients of this server.
+
+```
+skene serve [OPTIONS]
+```
+
+### Options
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--host TEXT` | | `127.0.0.1` | Interface to bind. Binding any non-localhost interface requires `--token`. |
+| `--port INT` | | `4906` | Port to listen on |
+| `--token TEXT` | | `$SKENE_SERVER_TOKEN` | Bearer token clients must send as `Authorization: Bearer <token>`. Required for non-localhost binds. |
+| `--db-path PATH` | | `$SKENE_DB_PATH` or `~/.local/share/skene/skene.db` | Path to the SQLite session database |
+| `--api-key TEXT` | | `$SKENE_API_KEY` or config | API key for the LLM provider |
+| `--provider TEXT` | `-p` | config value | LLM provider |
+| `--model TEXT` | `-m` | provider default | LLM model name |
+| `--base-url TEXT` | | `$SKENE_BASE_URL` or config | Base URL for OpenAI-compatible endpoints |
+| `--quiet` | `-q` | `false` | Suppress output, show errors only |
+| `--debug` | | `false` | Show diagnostic messages |
+
+### Behavior notes
+
+- `/health` is always unauthenticated; all other routes require the bearer token when one is set.
+- The server starts fine without LLM credentials — analyse requests then return `503` with the reason.
+- LLM configuration is resolved once at startup; changing it means restarting the server (there is deliberately no config-mutation API).
+- The session database is global (one per machine, all workspaces) and currently keeps everything — there is no GC command yet.
+- Auth is single-tenant: one optional token per server. Multi-tenancy is out of scope.
+
+See the [HTTP API reference](http-api.md) for routes, the event stream, and the domain model.
+
+---
+
+## `attach`
+
+Attach the CLI to a running `skene serve` instance.
+
+```
+skene attach <URL> [--token TEXT]
+skene attach --clear
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `URL` | Yes (unless `--clear`) | Base URL of the server, e.g. `http://127.0.0.1:4906` |
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--token TEXT` | `$SKENE_SERVER_TOKEN` | Bearer token for the server, if it requires one |
+| `--clear` | `false` | Detach: remove the saved server settings (mutually exclusive with `URL`) |
+
+### Behavior notes
+
+- Verifies the server by calling `GET /health` before saving anything.
+- Persists `server_url` and `server_token` into `.skene.config` — the project config if one exists (found by walking up from the current directory), otherwise the user config (`~/.config/skene/config`).
+- Once attached, `analyse-journey` runs on that server (see [Remote mode](#remote-mode)). Use `--clear` to go back to embedded runs.
 
 ---
 
@@ -430,6 +510,9 @@ See the [features guide](../guides/features.md) for detailed usage.
 | `SKENE_UPSTREAM_API_KEY` | `push`, `login` | API key for upstream authentication. |
 | `SKENE_DEBUG` | all commands | Enable debug mode (`true`/`false`). |
 | `SKENE_DB_URL` | `analyse-journey` | PostgreSQL connection string for live schema introspection. Equivalent to `--db-url`. |
+| `SKENE_SERVER_URL` | `analyse-journey` | URL of a remote `skene serve` instance. Equivalent to `--server`. |
+| `SKENE_SERVER_TOKEN` | `serve`, `attach`, `analyse-journey` | Bearer token for server auth. Equivalent to `--token` / `--server-token`. |
+| `SKENE_DB_PATH` | `serve`, `analyse-journey` | Path to the global SQLite session database. Equivalent to `serve --db-path`. |
 
 ---
 
@@ -497,4 +580,15 @@ uvx skene analyse-journey --db-url "postgresql://user:pass@localhost:5432/mydb"
 
 # Journey analysis with custom output
 uvx skene analyse-journey ./my-app --schema-dir ./schemas -o ./output/journey.yaml
+
+# Run the backend server headless (localhost)
+uvx skene serve --port 4906
+
+# Serve on all interfaces (token required)
+uvx skene serve --host 0.0.0.0 --token "my-secret"
+
+# Attach the CLI to a running server, then analyse remotely
+uvx skene attach http://127.0.0.1:4906
+uvx skene analyse-journey .          # now runs on the attached server
+uvx skene attach --clear             # back to embedded runs
 ```

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,0 +1,88 @@
+# HTTP API Reference
+
+The skene backend server (started with [`skene serve`](cli.md#serve)) exposes a REST + SSE API. The CLI's remote mode and the TUI are both clients of this API; you can use it directly to build your own integrations.
+
+- **Base URL:** `http://127.0.0.1:4906` by default.
+- **OpenAPI spec:** `GET /doc` (alias of `/openapi.json`). The SSE `Event` union is injected into the spec, so generated clients get typed event models. FastAPI's interactive docs are available at `/docs` and `/redoc`.
+- **Authentication:** if the server was started with a token, send `Authorization: Bearer <token>` on every request. `/health`, `/doc`, and the OpenAPI/docs endpoints are always unauthenticated. Auth is single-tenant — one optional token per server; multi-tenancy is out of scope.
+- **Workspaces:** all REST routes scope to a workspace (project directory) via the `x-skene-directory` header. Without the header, REST routes fall back to the server's working directory. The `/event` stream is the exception: with the header it filters to that workspace, without it it streams events for **all** workspaces.
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/event` | SSE stream of server events (see [Events](#events)) |
+| `POST` | `/session` | Create a session `{agent?, parentId?, title?}` → `201` |
+| `GET` | `/session` | List sessions (workspace-scoped) |
+| `GET` | `/session/{id}` | Get one session |
+| `GET` | `/session/{id}/children` | Child sessions (subagent runs) |
+| `GET` | `/session/{id}/message` | Messages with their parts |
+| `POST` | `/session/{id}/message` | Prompt the session → `202` with the created user message; the run is async — watch `/event`. `409` if the session is already running. |
+| `POST` | `/session/{id}/abort` | Cancel the session and its whole child-session tree → `{"aborted": bool}` |
+| `GET` | `/session/{id}/permissions` | Permission asks raised by the session |
+| `POST` | `/session/{id}/permissions/{permID}` | Answer an ask: `{"reply": "allow" \| "deny"}` |
+| `GET` | `/agent` | Agent registry (primary agent + subagents) |
+| `GET` | `/provider` | Supported LLM providers, active one marked |
+| `GET` | `/config` | Resolved server config, secrets redacted (read-only — there is no config-mutation API) |
+| `POST` | `/journey/analyse` | Start a canned journey analysis → `202 {"sessionId": ...}`; `503` if the server has no LLM credentials |
+| `GET` | `/journey` | The workspace's `journey.yaml` as JSON (`404` if none exists yet) |
+| `GET` | `/health` | `{"status": "ok", "version": ...}` — always unauthenticated |
+
+## Domain model
+
+**Session** — one agent run. Fields include `status` (`idle` | `running` | `error`) and `parentId`: a subagent run is a child session linked to its parent, so a journey analysis is a session tree. Aborting a parent cancels the entire tree.
+
+**Message** — belongs to a session; role is `user`, `assistant`, or `synthetic`.
+
+**Part** — a piece of message content. Types: `text`, `reasoning`, `tool`, `milestone`, `artifact`. Tool parts carry streaming state (`running` → `completed` | `error`). During journey analysis, candidate milestones stream as `milestone` parts in the child sessions, and the finished run puts an `artifact` part (the written `journey.yaml`) in the parent session.
+
+Messages and parts are **upserts keyed by id** — on a `*.updated` event, clients just overwrite their copy.
+
+### Agents
+
+`GET /agent` lists the registry: `skene` (primary — orchestrates a run) plus the `code` and `schema` subagents. The primary agent spawns subagents through a `task` tool; multiple `task` calls in one turn run subagents in parallel. Agent definitions may carry a per-agent `model` override, honoured when the server's LLM factory supports it.
+
+## Events
+
+`GET /event` is a Server-Sent Events stream. Frames use `data:`-only framing, one JSON object per frame, shaped `{id, type, properties}`. A heartbeat is sent after 10 seconds of silence.
+
+| Event type | Meaning |
+|------------|---------|
+| `server.connected` | Stream opened |
+| `server.heartbeat` | Keep-alive (after 10s of silence) |
+| `session.created` / `session.updated` | Session lifecycle; watch `status` |
+| `session.idle` | Run finished |
+| `session.error` | Run failed |
+| `message.created` / `message.updated` | Message upserts |
+| `part.created` / `part.updated` | Part upserts (tool state, streaming text deltas, milestones, artifacts) |
+| `permission.asked` / `permission.answered` | Permission flow (see below) |
+
+## Permissions
+
+The permission flow (`GET/POST /session/{id}/permissions*` plus the `permission.*` events) is the mechanism for guarded operations — a run pauses, raises an ask, and resumes once a client answers `allow` or `deny`. Answers are one-shot and there is no timeout; aborting a run auto-denies its pending asks.
+
+No built-in tool raises asks yet — the mechanism exists end-to-end for future guarded operations (for example database writes).
+
+## Typical flow: run a journey analysis
+
+```bash
+# 1. Open the event stream for your workspace (keep it running)
+curl -N -H "x-skene-directory: /path/to/project" http://127.0.0.1:4906/event
+
+# 2. Start the analysis
+curl -X POST -H "x-skene-directory: /path/to/project" \
+     -H "content-type: application/json" -d '{}' \
+     http://127.0.0.1:4906/journey/analyse
+# → 202 {"sessionId": "..."}
+
+# 3. Watch session/message/part events stream; the run is done on session.idle
+
+# 4. Fetch the result
+curl -H "x-skene-directory: /path/to/project" http://127.0.0.1:4906/journey
+```
+
+## Storage
+
+Every session is persisted in a global SQLite database (WAL mode) at `~/.local/share/skene/skene.db`, overridable with `SKENE_DB_PATH` or `skene serve --db-path`. It holds sessions for every workspace; retention is keep-everything (no GC command yet).
+
+> **Pre-1.0 caveat:** the milestone wire shape changed during development — very old dev databases can return `500` on read. Deleting the DB file fixes it.

--- a/tui/README.md
+++ b/tui/README.md
@@ -8,7 +8,7 @@ Built with Go and [Bubble Tea](https://github.com/charmbracelet/bubbletea).
 
 Skene terminal is the interactive front-end for **Skene** — a PLG analysis toolkit that models your product's user journey from your schema and code, surfaces growth opportunities along it, and turns them into actionable implementation plans.
 
-The tool itself does **not** perform any analysis. It orchestrates `uvx skene` in your selected repository directory and displays the results.
+The tool itself does **not** perform any analysis — it is a client of the skene backend. For journey analysis it spawns a local `skene serve` on a free port (or attaches to an existing server via `SKENE_SERVER_URL`) and renders the server's live event stream; legacy commands (`analyze`, `plan`, `build`, `validate`, `push`) still run one-shot via `uvx skene`.
 
 ## Features
 
@@ -16,10 +16,12 @@ The tool itself does **not** perform any analysis. It orchestrates `uvx skene` i
 - Multiple AI providers — OpenAI, Anthropic, Gemini or any OpenAI-compatible endpoint
 - Authentication — Skene magic link, API key entry, local model auto-detection
 - Existing analysis detection — detects previous `skene-context/` (or legacy `skene/`) output and offers to view or re-run
-- Live terminal output during analysis
+- Server-backed journey analysis — spawns `skene serve` (or attaches to a remote one) and renders structured per-agent, per-tool progress from the server's SSE event stream
+- Browser journey visualizer — reads the journey from the server's `GET /journey` endpoint
 - Tabbed results view — User Journey, Growth Manifest, Growth Plan, Engine
-- Next steps menu — generate plans, build prompts, validate, or re-analyse
-- Cancellable processes — press `Esc` to cancel a running analysis
+- Next steps menu — generate plans, build prompts, validate, re-analyse, or deploy to Skene Cloud
+- Explicit publishing — nothing is pushed to Skene Cloud until you choose **"Deploy to Skene Cloud"**
+- Cancellable processes — press `Esc` to cancel a running analysis (remote runs are aborted on the server)
 - Error handling with retry and go-back
 - Cross-platform — macOS, Linux, Windows
 - Mini-game while you wait
@@ -41,7 +43,7 @@ This downloads the latest release binary for your platform and installs it to `/
 To install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/SkeneTechnologies/skene/main/tui/install.sh | VERSION=tui-v0.4.0 bash
+curl -fsSL https://raw.githubusercontent.com/SkeneTechnologies/skene/main/tui/install.sh | VERSION=tui-v0.5.1 bash
 ```
 
 ### Clone and Run
@@ -119,6 +121,15 @@ Example `.skene.config`:
 }
 ```
 
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `SKENE_SERVER_URL` | Attach to an already-running `skene serve` instead of spawning one |
+| `SKENE_SERVER_TOKEN` | Bearer token sent to the attached server |
+
+When the TUI spawns its own server, it passes the wizard's LLM configuration to it via `SKENE_API_KEY`, `SKENE_PROVIDER`, `SKENE_MODEL`, and `SKENE_BASE_URL`.
+
 ### Supported Providers
 
 | Provider | ID | Auth |
@@ -136,9 +147,12 @@ make dev          # live reload (requires air)
 make test         # run tests
 make lint         # lint
 make fmt          # format
+make generate     # regenerate the Go API client from the server's OpenAPI spec (requires uv)
 make build-all    # build for all platforms
 make release      # package releases
 ```
+
+The Go API client (`internal/api/client.gen.go`) is generated from the Python server's OpenAPI spec and checked in. Regeneration is manual: run `make generate` whenever the server API changes.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Updates all user-facing documentation for the backend-server rearchitecture (PRs #95–#99), following the handoff notes in `docs/design/server-rearchitecture-docs-handoff.md` (deleted here, per its own instructions). Every documented flag, route, default, and behavior was verified against the code on this branch before writing.

- **CLI reference**: new `serve` and `attach` entries; `analyse-journey` updated for the agentic/embedded-server model with a new *Remote mode* section (`--server` / `--server-token`, server-side path resolution, Ctrl-C aborts the remote run, session traces); env-var table (`SKENE_SERVER_URL`, `SKENE_SERVER_TOKEN`, `SKENE_DB_PATH`) and examples extended
- **New `docs/reference/http-api.md`**: route table, Session/Message/Part domain model, SSE event contract, permission flow, curl walkthrough, storage notes (including the `/event`-without-header global-stream nuance and the 202-returns-Message nuance)
- **Configuration guide**: `server_url` / `server_token` keys, attach flow, global session database
- **Push guide + quickstart**: auto-publish is gone from the product — docs now say publishing only happens via explicit `skene push` / "Deploy to Skene Cloud"
- **TUI README + root README**: server spawn/attach model, structured SSE progress, `GET /journey` visualizer, explicit-publish note, `make generate`, install-example version bump (v0.4.0 → v0.5.1)
- **`llms.txt` / `index.md`**: enumerate `serve`/`attach` and the HTTP API

Deliberately left undocumented: the hidden TUI-only `--auto-publish` flag on `analyse-journey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
